### PR TITLE
Fix the portuguese locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ underscore, because that is what Salesforce is expecting to find.
 
 ## Release Notes
 
+### 1.0.4
+
+- Apparently in Salesforce Portuguese has no default. This fix makes sure that
+  both pt-PT and pt-BR are fully specified with neither of them being the default
+  for "pt" by itself
+
+### 1.0.3
+
+- Fixed a problem with nb-NO and es-419 which Salesforce do not support
+    - mapped to "no" and "es-MX" respectively
+
 ### 1.0.2
 
 - add the sflocales.json config file to the package

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-salesforce-metaxml",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "main": "./MetaXmlFileType.js",
     "description": "A loctool plugin that knows how to process Salesforce *-meta.xml files",
     "license": "Apache-2.0",

--- a/sflocales.json
+++ b/sflocales.json
@@ -47,7 +47,6 @@
     "no-NO": "no",
     "nb-NO": "no",
     "pl-PL": "pl",
-    "pt-BR": "pt",
     "rm-CH": "rm",
     "ro-RO": "ro",
     "ru-RU": "ru",

--- a/test/testMetaXmlFile.js
+++ b/test/testMetaXmlFile.js
@@ -1127,6 +1127,21 @@ module.exports.metaxmlfile = {
         test.done();
     },
 
+    testMetaXmlFileGetLocalizedPathSpecialMappingPortugueseNoDefault: function(test) {
+        test.expect(3);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./en_US.translation-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        test.equal(mxf.getLocalizedPath("pt_PT"), "pt_PT.translation-meta.xml");
+        test.equal(mxf.getLocalizedPath("pt_BR"), "pt_BR.translation-meta.xml");
+        test.done();
+    },
+
     testMetaXmlFileLocalizeSimple: function(test) {
         test.expect(2);
 


### PR DESCRIPTION
- Apparently in Salesforce Portuguese has no default. This fix makes sure that both pt-PT and pt-BR are fully specified with neither of them being the default for "pt" by itself
- Why can't the salesforce cli give me all the errors in an source::push all at once? I don't know. Hopefully, this is the last error, or else we'll have to make yet another version of this plugin to fix more of them