### PR TITLE
Fix initialization of pseudo locales

### DIFF
--- a/MetaXmlFileType.js
+++ b/MetaXmlFileType.js
@@ -45,7 +45,7 @@ var MetaXmlFileType = function(project) {
     this.pseudos = {};
 
     // generate all the pseudo bundles we'll need
-    project.locales && project.locales.forEach(function(locale) {
+    project.settings && project.settings.locales && project.settings.locales.forEach(function(locale) {
         var pseudo = this.API.getPseudoBundle(locale, this, project);
         if (pseudo) {
             this.pseudos[locale] = pseudo;

--- a/README.md
+++ b/README.md
@@ -8,7 +8,18 @@ translated files in the same directory with the "en_US" replaced with the name o
 the target locale. The dash in the standard BCP-47 locale name is replaced with an
 underscore, because that is what Salesforce is expecting to find.
 
+## License
+
+This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+file for more details.
+
 ## Release Notes
+
+### v1.0.5
+
+- Fix a bug where the pseudo locales were not initialized properly.
+  This fix gets the right set of locales from the project settings to
+  see if any of them are pseudo locales.
 
 ### 1.0.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-salesforce-metaxml",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "main": "./MetaXmlFileType.js",
     "description": "A loctool plugin that knows how to process Salesforce *-meta.xml files",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -55,12 +55,12 @@
     },
     "dependencies": {
         "assertextras": "^1.1.0",
-        "ilib": "^14.6.1",
+        "ilib": "^14.9.0",
         "log4js": "^2.11.0",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
-        "loctool": "^2.10.0",
+        "loctool": "^2.13.0",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
- Fix a bug where the pseudo locales were not initialized properly. This fix gets the right set of locales from the project settings to see if any of them are pseudo locales.