### PR TITLE
Retrieve source strings from other meta.xml files

### DIFF
--- a/MetaXmlFile.js
+++ b/MetaXmlFile.js
@@ -20,14 +20,19 @@
 var ilib = require("ilib");
 var fs = require("fs");
 var path = require("path");
-var log4js = require("log4js");
 var xmljs = require("xml-js");
 
 var IString = require("ilib/lib/IString");
 var Locale = require("ilib/lib/Locale");
 var sfLocales = require("./sflocales.json");
 
-var logger = log4js.getLogger("loctool.lib.MetaXmlFile");
+var logger = {
+    error: function() {},
+    info: function() {},
+    warn: function() {},
+    debug: function() {},
+    trace: function() {}
+};
 
 /**
  * Create a new java file with the given path name and within
@@ -46,14 +51,21 @@ var MetaXmlFile = function(options) {
 
     this.API = this.project.getAPI();
 
+    if (typeof(this.API.getLogger) === "function") {
+        logger = this.API.getLogger("loctool.lib.MetaXmlFileType");
+    }
+
     this.set = this.API.newTranslationSet(this.project ? this.project.sourceLocale : "zxx-XX");
     this.mapping = this.type.getMapping(this.pathName);
     this.schema = this.mapping ? this.type.getSchema(this.mapping.schema) : this.type.getDefaultSchema();
     this.resourceIndex = 0;
+    this.locale = new Locale(options.locale || "en-US");
 
     this.xmlFile = this.type.xmlFileType.newFile(this.pathName, {
         mapping: this.mapping
     });
+
+    this.translationFile = this.isTranslationFile(this.pathName);
 };
 
 var reUnicodeChar = /\\u([a-fA-F0-9]{1,4})/g;
@@ -118,6 +130,7 @@ MetaXmlFile.cleanString = function(string) {
     return unescaped;
 };
 
+
 /**
  * Make a new key for the given string. This must correspond
  * exactly with the code in htglob jar file so that the
@@ -134,153 +147,37 @@ MetaXmlFile.prototype.makeKey = function(source) {
     return this.API.utils.hashKey(MetaXmlFile.cleanString(source));
 };
 
-var skipProperties = {
-    "_attributes": true,
-    "_declaration": true
+MetaXmlFile.prototype.isTranslationFile = function(pathName) {
+    return !pathName || pathName.endsWith(".translation-meta.xml");
 };
 
-MetaXmlFile.prototype.addResource = function(key, text, comment, autoKey, context) {
-    if (!this.API.utils.isDNT(comment)) {
-        if (!key) {
-            key = this.makeKey(text);
-            autoKey = true;
-        }
-        var res = this.API.newResource({
-            datatype: this.type.datatype,
-            resType: "string",
-            key: key,
-            source: text,
-            pathName: this.pathName,
-            sourceLocale: this.locale || this.sourceLocale,
-            project: this.project.getProjectId(),
-            autoKey: autoKey,
-            comment: comment,
-            dnt: this.API.utils.isDNT(comment),
-            index: this.resourceIndex++,
-            context: context
-        });
-        this.set.add(res);
-        this.dirty = true;
-    }
-};
-
-function textOrComment(node) {
-    return (node._text && node._text.trim()) || (node._comment && node._comment.trim());
-}
-
-MetaXmlFile.prototype.handleCustom = function(context, subnode) {
-    var text, key, comment, autoKey;
-
-    if (subnode.name && subnode.name._text) {
-        key = subnode.name._text.trim();
-        autoKey = false;
-    }
-
-    comment = subnode._comment && subnode._comment.trim();
-
-    if (subnode.label) {
-        text = textOrComment(subnode.label);
-        if (text && text.length) {
-            if (subnode._attributes) {
-                comment = subnode._attributes["x-i18n"];
+MetaXmlFile.prototype.addResource = function(res) {
+    logger.trace("MetaXmlFile.addResource: " + JSON.stringify(res) + " to " + this.project.getProjectId() + ", " + this.locale + ", " + JSON.stringify(this.context));
+    if (this.translationFile) {
+        var ourResource = this.set.get(res.hashKey());
+        if (!ourResource) {
+            this.set.add(res);
+        } else {
+            switch (res.getType()) {
+                default:
+                case "string":
+                    if (!ourResource.getSource()) {
+                        ourResource.setSource(res.getSource());
+                    }
+                    break;
+                case "plural":
+                    if (!ourResource.getSourcePlurals()) {
+                        ourResource.setSourcePlurals(res.getSourcePlurals());
+                    }
+                    break;
+                case "array":
+                    if (!ourResource.getSourceArray()) {
+                        ourResource.setSourceArray(res.getSourceArray());
+                    }
+                    break;
             }
-            logger.trace("Found resource type " + context + " with string " + text + " and comment " + comment);
-            this.addResource(key, text, comment, autoKey, context);
         }
-    }
-
-    if (subnode.description) {
-        text = textOrComment(subnode.description);
-        if (text && text.length) {
-            if (subnode._attributes) {
-                comment = subnode._attributes["x-i18n"];
-            }
-            logger.trace("Found resource type " + context + " with string " + text + " and comment " + comment);
-            this.addResource(key + ".description", text, comment, autoKey, context);
-        }
-    }
-}
-
-MetaXmlFile.prototype.handleReportTypes = function(context, subnode) {
-    var text, key, comment, autoKey;
-
-    if (subnode.name && subnode.name._text) {
-        key = subnode.name._text.trim();
-        autoKey = false;
-    }
-
-    comment = subnode._comment;
-
-    if (subnode.description) {
-        text = textOrComment(subnode.description);
-        if (text && text.length) {
-            if (subnode._attributes) {
-                comment = subnode._attributes["x-i18n"];
-            }
-            logger.trace("Found resource type " + context + " with string " + text + " and comment " + comment);
-            this.addResource(key + ".description", text, comment, autoKey, context);
-        }
-    }
-
-    if (subnode.label) {
-        text = textOrComment(subnode.label);
-        if (text && text.length) {
-            if (subnode._attributes) {
-                comment = subnode._attributes["x-i18n"];
-            }
-            logger.trace("Found resource type " + context + " with string " + text + " and comment " + comment);
-            this.addResource(key, text, comment, autoKey, context);
-        }
-    }
-
-    if (subnode.sections) {
-        var sections = ilib.isArray(subnode.sections) ? subnode.sections : [ subnode.sections ];
-        for (var i = 0; i < sections.length; i++) {
-            autoKey = false;
-            var section = sections[i];
-            var label = textOrComment(section.label);
-            var subkey = textOrComment(section.name);
-            if (!subkey) {
-                subkey = this.makeKey(label);
-                autoKey = true;
-            }
-            subkey = [key, subkey].join('.');
-            this.addResource(subkey, label, comment, autoKey, context + ".sections");
-        }
-    }
-}
-
-var localizableElements = {
-    "customApplications": true,
-    "customLabels": true,
-    "customTabs": true,
-    "quickActions": true,
-    "reportTypes": true
-};
-
-/**
- * Walk the node tree looking for properties that have localizable values, then extract
- * them and resourcify them.
- * @private
- */
-MetaXmlFile.prototype.walkLayout = function(node) {
-    var comment, id, subnodes, subnode, text, autoKey;
-
-    for (var p in node) {
-        if (p in localizableElements) {
-            subnodes = ilib.isArray(node[p]) ? node[p] : [ node[p] ];
-            for (var i = 0; i < subnodes.length; i++) {
-                subnode = subnodes[i];
-                if (p === "reportTypes") {
-                    this.handleReportTypes(p, subnode);
-                } else {
-                    this.handleCustom(p, subnode);
-                }
-            }
-        } else if (typeof(node[p]) === "object" && !(p in skipProperties)) {
-            this.walkLayout(node[p]);
-        }
-    }
+    } // else do not add a resource to a non translation file
 };
 
 /**
@@ -292,18 +189,14 @@ MetaXmlFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
 
     this.xmlFile.parse(data);
-
-    /*
-    this.xml = data;
-    this.contents = xmljs.xml2js(data, {
-        trim: false,
-        nativeTypeAttribute: true,
-        compact: true
-    });
-    this.resourceIndex = 0;
-
-    this.walkLayout(this.contents);
-    */
+    if (this.translationFile) {
+        var xmlSet = this.xmlFile.getTranslationSet();
+        if (xmlSet.size() > 0) {
+            this.set.addSet(xmlSet);
+            // clean = no resources added yet
+            this.set.setClean();
+        }
+    }
 };
 
 /**
@@ -333,7 +226,10 @@ MetaXmlFile.prototype.extract = function() {
  * current MetaXml file.
  */
 MetaXmlFile.prototype.getTranslationSet = function() {
-    return this.xmlFile.set;
+    if (this.set.size() === 0 && this.xmlFile.set.size() > 0) {
+        this.set.addSet(this.xmlFile.set);
+    }
+    return this.set;
 }
 
 /**
@@ -343,16 +239,7 @@ MetaXmlFile.prototype.getTranslationSet = function() {
  * @returns {String} the localized path name
  */
 MetaXmlFile.prototype.getLocalizedPath = function(locale) {
-    var spec = locale || this.project.sourceLocale;
-    if (sfLocales[spec]) {
-        spec = sfLocales[spec];
-    }
-    spec = spec.replace(/-/g, "_");
-
-    var filename = path.basename(this.pathName);
-    var dirname = path.dirname(this.pathName);
-
-    return this.type.smartJoin(dirname, spec + ".translation-meta.xml");
+    return this.type.getResourceFilePath(locale);
 };
 
 /**
@@ -364,6 +251,8 @@ MetaXmlFile.prototype.getLocalizedPath = function(locale) {
  * @returns {String} the localized text of this file
  */
 MetaXmlFile.prototype.localizeText = function(translations, locale) {
+    return this.translationFile && this.xmlFile.localizeText(translations, locale);
+
 /*
     var output = {
         _declaration: {
@@ -480,6 +369,12 @@ MetaXmlFile.prototype.localizeText = function(translations, locale) {
  * @param {Array.<String>} locales array of locales to translate to
  */
 MetaXmlFile.prototype.localize = function(translations, locales) {
+    // don't localize these files individually. Instead, wait until
+    // all of the files have been read and then use MetaXmlFileType.write()
+    // to find all of the non translation files and distribute their
+    // resources to the translation files, then write out each translation
+    // file
+
     /*
     // don't localize if there is no text
     if (this.set.size() > 0 && translations && translations.size() > 0 && locales && locales.length > 0) {

--- a/MetaXmlFileType.js
+++ b/MetaXmlFileType.js
@@ -91,6 +91,8 @@ var MetaXmlFileType = function(project) {
  * Join two paths unless the child is an absolute path
  */
 MetaXmlFileType.prototype.smartJoin = function(parent, child) {
+    if (!parent) return child;
+    if (!child) return parent;
     return (child[0] === "/") ? child : path.join(parent, child);
 }
 

--- a/MetaXmlFileType.js
+++ b/MetaXmlFileType.js
@@ -351,7 +351,7 @@ MetaXmlFileType.prototype.addSet = function(set) {
  * new resources
  */
 MetaXmlFileType.prototype.getNew = function() {
-    return this.newres;
+    return this.xmlFileType.getNew();
 };
 
 /**
@@ -362,7 +362,7 @@ MetaXmlFileType.prototype.getNew = function() {
  * pseudo localized resources
  */
 MetaXmlFileType.prototype.getPseudo = function() {
-    return this.pseudo;
+    return this.xmlFileType.getPseudo();
 };
 
 /**

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.1.0
+
+- now uses ilib-loctool-xml plugin to parse various meta xml files to look for
+  source strings
+
 ### v1.0.5
 
 - Fix a bug where the pseudo locales were not initialized properly.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,80 @@ translated files in the same directory with the "en_US" replaced with the name o
 the target locale. The dash in the standard BCP-47 locale name is replaced with an
 underscore, because that is what Salesforce is expecting to find.
 
+This plugin will also read other meta xml files in the project to find source strings
+that may be missing in the translation-meta.xml file. The following meta xml file
+types are read:
+
+* app-meta.xml
+* customPermission-meta.xml
+* listView-meta.xml
+* field-meta.xml
+* labels-meta.xml
+* md-meta.xml
+* object-meta.xml
+* permissionset-meta.xml
+* quickAction-meta.xml
+* tab-meta.xml
+
+All strings gleaned from those files are used to augment the strings found in the
+translations-meta.xml file with a source string.
+
+## Configuration
+
+The plugin will look for the `xml` property within the `settings`
+of your `project.json` file. The following settings are
+used within the json property:
+
+- schemas: a string naming a directory full of JSON schema files, or
+  an array of strings naming some JSON schema files or directories to
+  load. If the XML file
+  does not fit any of the schema (ie. it does not validate according to
+  any one of the schema), then that file will be skipped and not localized.
+  Schemas files are discussed below.
+- resourceFile: a path name template specifying where the translation-meta.xml
+  for this salesforce app lives. Default is:
+  "force-app/main/default/translations/[localeUnder].translation-meta.xml"
+- mappings: a mapping between file matchers and an object that gives
+  info used to localize the files that match it. This allows different
+  meta xml files within the project to be processed with different schema.
+  This is mainly for meta xml file types that are not the standard ones
+  mentioned above.
+  The matchers are
+  a [micromatch-style string](https://www.npmjs.com/package/micromatch),
+  similar to the the `includes` and `excludes` section of a
+  `project.json` file. The value of that mapping is an object that
+  can contain the following properties:
+    - schema: schema to use with that matcher. The schema is
+      specified using the `$id` of one of the schemas loaded in the
+      `schemas` property above. The default schema is "properties-schema"
+      which is given in the previous section.
+
+Example configuration:
+
+```json
+    "settings": {
+        "metaxml": {
+            "schemas": "./xml/schemas",
+            "resourceFile": "force-app/main/foo/translations/[localeUnder].translation-meta.xml",
+            "mappings": {
+                "**/*.page-meta.xml": {
+                    "schema": "my-page-meta-schema"
+                }
+            }
+        }
+    }
+```
+
+In the above example, any file named `*.page-meta.xml` will be parsed with the
+`my-page-meta-schema` schema found in the `xml/schemas` directory. (See the
+documentation of the (ilib-loctool-xml)[https://github.com/iLib-js/ilib-loctool-xml/blob/main/README.md]
+plugin for details on that.) The
+resources from that file will go to augment the source strings of the strings
+found in the resource file translation meta xml.
+
+The resource file will be written out to a file named
+`force-app/main/foo/translations/[localeUnder].translation-meta.xml`.
+
 ## License
 
 This plugin is license under Apache2. See the [LICENSE](./LICENSE)
@@ -18,7 +92,12 @@ file for more details.
 ### v1.1.0
 
 - now uses ilib-loctool-xml plugin to parse various meta xml files to look for
-  source strings
+  source strings. These types are parsed automatically and their schema is
+  built-in to this plugin already.
+- added the ability to specify a resource file for output of the translations
+- added the ability to do mappings to read other types of meta xml that
+  are not the standard ones listed above
+- updated dependencies
 
 ### v1.0.5
 

--- a/package.json
+++ b/package.json
@@ -56,13 +56,14 @@
     },
     "dependencies": {
         "ilib": "^14.11.1",
-        "ilib-loctool-xml": "^1.0.0",
+        "ilib-loctool-xml": "^1.1.0",
+        "log4js": "^6.3.0",
         "micromatch": "^4.0.4",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "^2.16.0",
+        "loctool": "^2.16.2",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-salesforce-metaxml",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "main": "./MetaXmlFileType.js",
     "description": "A loctool plugin that knows how to process Salesforce *-meta.xml files",
     "license": "Apache-2.0",
@@ -38,7 +38,8 @@
         "LICENSE",
         "MetaXmlFileType.js",
         "MetaXmlFile.js",
-        "sflocales.json"
+        "sflocales.json",
+        "schemas"
     ],
     "repository": {
         "type": "git",
@@ -54,13 +55,15 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "assertextras": "^1.1.0",
-        "ilib": "^14.9.0",
+        "ilib": "^14.10.0",
+        "ilib-loctool-xml": "^1.0.0",
         "log4js": "^2.11.0",
+        "micromatch": "^4.0.4",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
-        "loctool": "^2.13.0",
+        "assertextras": "^1.1.0",
+        "loctool": "^2.15.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -55,15 +55,14 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.10.0",
+        "ilib": "^14.11.1",
         "ilib-loctool-xml": "^1.0.0",
-        "log4js": "^2.11.0",
         "micromatch": "^4.0.4",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "^2.15.0",
+        "loctool": "^2.16.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/schemas/customApplication-meta-xml-schema.json
+++ b/schemas/customApplication-meta-xml-schema.json
@@ -9,6 +9,7 @@
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",

--- a/schemas/customApplication-meta-xml-schema.json
+++ b/schemas/customApplication-meta-xml-schema.json
@@ -15,7 +15,7 @@
                             "type": "string",
                             "localizableType": {
                                 "source": "_value",
-                                "key": "_value"
+                                "key": "_basename"
                             }
                         }
                     }

--- a/schemas/customApplication-meta-xml-schema.json
+++ b/schemas/customApplication-meta-xml-schema.json
@@ -1,0 +1,36 @@
+{
+    "$id": "customApplication-meta-xml-schema",
+    "type": "object",
+    "properties": {
+        "CustomApplication": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value",
+                                "key": "_value"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "comment": "_value"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/customField-meta-xml-schema.json
+++ b/schemas/customField-meta-xml-schema.json
@@ -1,0 +1,89 @@
+{
+    "$id": "customField-meta-xml-schema",
+    "type": "object",
+    "$defs": {
+        "entry-type": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value"
+                            }
+                        }
+                    }
+                },
+                "fullName": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "key": "_value"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "properties": {
+        "CustomField": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value"
+                            }
+                        }
+                    }
+                },
+                "fullName": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "key": "_value"
+                            }
+                        }
+                    }
+                },
+                "valueSet": {
+                    "type": "object",
+                    "properties": {
+                        "valueSetDefinition": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/$defs/entry-type"
+                                            }
+                                        },
+                                        {
+                                            "$ref": "#/$defs/entry-type"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/customField-meta-xml-schema.json
+++ b/schemas/customField-meta-xml-schema.json
@@ -9,6 +9,7 @@
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",
@@ -20,6 +21,7 @@
                 },
                 "fullName": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",
@@ -40,6 +42,7 @@
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",

--- a/schemas/customLabels-meta-xml-schema.json
+++ b/schemas/customLabels-meta-xml-schema.json
@@ -6,9 +6,11 @@
             "type": "object",
             "localizable": true,
             "localizableType": "string",
+            "required": ["value"],
             "properties": {
                 "value": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",

--- a/schemas/customLabels-meta-xml-schema.json
+++ b/schemas/customLabels-meta-xml-schema.json
@@ -1,0 +1,77 @@
+{
+    "$id": "customLabels-meta-xml-schema",
+    "type": "object",
+    "$defs": {
+        "entry-type": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "value": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value"
+                            }
+                        }
+                    }
+                },
+                "fullName": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "key": "_value"
+                            }
+                        }
+                    }
+                },
+                "language": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "locale": "_value"
+                            }
+                        }
+                    }
+                },
+                "shortDescription": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "comment": "_value"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "properties": {
+        "CustomLabels": {
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/entry-type"
+                            }
+                        },
+                        {
+                            "$ref": "#/$defs/entry-type"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/schemas/customMetadata-meta-xml-schema.json
+++ b/schemas/customMetadata-meta-xml-schema.json
@@ -9,6 +9,7 @@
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",

--- a/schemas/customMetadata-meta-xml-schema.json
+++ b/schemas/customMetadata-meta-xml-schema.json
@@ -1,0 +1,36 @@
+{
+    "$id": "customMetadata-meta-xml-schema",
+    "type": "object",
+    "properties": {
+        "CustomMetadata": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value",
+                                "key": "_value"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "comment": "_value"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/customMetadata-meta-xml-schema.json
+++ b/schemas/customMetadata-meta-xml-schema.json
@@ -15,7 +15,7 @@
                             "type": "string",
                             "localizableType": {
                                 "source": "_value",
-                                "key": "_value"
+                                "key": "_basename"
                             }
                         }
                     }

--- a/schemas/customObject-meta-xml-schema.json
+++ b/schemas/customObject-meta-xml-schema.json
@@ -15,7 +15,7 @@
                             "type": "string",
                             "localizableType": {
                                 "source": "_value",
-                                "key": "_value",
+                                "key": "_basename",
                                 "category": "one"
                             }
                         }
@@ -59,7 +59,8 @@
                                     "type": "string",
                                     "localizableType": {
                                         "source": "_value",
-                                        "key": "_value"
+                                        "key": "_basename",
+                                        "context": "_path"
                                     }
                                 }
                             }

--- a/schemas/customObject-meta-xml-schema.json
+++ b/schemas/customObject-meta-xml-schema.json
@@ -1,0 +1,79 @@
+{
+    "$id": "customObject-meta-xml-schema",
+    "type": "object",
+    "properties": {
+        "CustomObject": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "plural",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value",
+                                "key": "_value",
+                                "category": "one"
+                            }
+                        }
+                    }
+                },
+                "pluralLabel": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value",
+                                "category": "other"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "comment": "_value"
+                            }
+                        }
+                    }
+                },
+                "nameField": {
+                    "type": "object",
+                    "localizable": true,
+                    "localizableType": "string",
+                    "properties": {
+                        "label": {
+                            "type": "object",
+                            "properties": {
+                                "_text": {
+                                    "type": "string",
+                                    "localizableType": {
+                                        "source": "_value",
+                                        "key": "_value"
+                                    }
+                                }
+                            }
+                        },
+                        "description": {
+                            "type": "object",
+                            "properties": {
+                                "_text": {
+                                    "type": "string",
+                                    "localizableType": {
+                                        "comment": "_value"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/customObject-meta-xml-schema.json
+++ b/schemas/customObject-meta-xml-schema.json
@@ -9,6 +9,7 @@
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",
@@ -22,6 +23,7 @@
                 },
                 "pluralLabel": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",
@@ -47,9 +49,11 @@
                     "type": "object",
                     "localizable": true,
                     "localizableType": "string",
+                    "required": ["label"],
                     "properties": {
                         "label": {
                             "type": "object",
+                            "required": ["_text"],
                             "properties": {
                                 "_text": {
                                     "type": "string",

--- a/schemas/customPermission-meta-xml-schema.json
+++ b/schemas/customPermission-meta-xml-schema.json
@@ -6,9 +6,11 @@
             "type": "object",
             "localizable": true,
             "localizableType": "string",
+            "required": ["label"],
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",

--- a/schemas/customPermission-meta-xml-schema.json
+++ b/schemas/customPermission-meta-xml-schema.json
@@ -1,0 +1,36 @@
+{
+    "$id": "customPermission-meta-xml-schema",
+    "type": "object",
+    "properties": {
+        "CustomPermission": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value",
+                                "key": "_value"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "comment": "_value"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/customTab-meta-xml-schema.json
+++ b/schemas/customTab-meta-xml-schema.json
@@ -1,8 +1,8 @@
 {
-    "$id": "customPermission-meta-xml-schema",
+    "$id": "customtab-meta-xml-schema",
     "type": "object",
     "properties": {
-        "CustomPermission": {
+        "CustomTab": {
             "type": "object",
             "localizable": true,
             "localizableType": "string",
@@ -16,13 +16,14 @@
                             "type": "string",
                             "localizableType": {
                                 "source": "_value",
-                                "key": "_value"
+                                "key": "_basename"
                             }
                         }
                     }
                 },
                 "description": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",

--- a/schemas/customTab-meta-xml-schema.json
+++ b/schemas/customTab-meta-xml-schema.json
@@ -6,9 +6,11 @@
             "type": "object",
             "localizable": true,
             "localizableType": "string",
+            "required": ["label"],
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",

--- a/schemas/customTab-meta-xml-schema.json
+++ b/schemas/customTab-meta-xml-schema.json
@@ -1,0 +1,36 @@
+{
+    "$id": "customPermission-meta-xml-schema",
+    "type": "object",
+    "properties": {
+        "CustomPermission": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value",
+                                "key": "_value"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "comment": "_value"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schemas/listview-meta-xml-schema.json
+++ b/schemas/listview-meta-xml-schema.json
@@ -1,8 +1,8 @@
 {
-    "$id": "customPermission-meta-xml-schema",
+    "$id": "listview-meta-xml-schema",
     "type": "object",
     "properties": {
-        "CustomPermission": {
+        "ListView": {
             "type": "object",
             "localizable": true,
             "localizableType": "string",
@@ -15,19 +15,19 @@
                         "_text": {
                             "type": "string",
                             "localizableType": {
-                                "source": "_value",
-                                "key": "_basename"
+                                "source": "_value"
                             }
                         }
                     }
                 },
-                "description": {
+                "fullName": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",
                             "localizableType": {
-                                "comment": "_value"
+                                "key": "_value"
                             }
                         }
                     }

--- a/schemas/permissionset-meta-xml-schema.json
+++ b/schemas/permissionset-meta-xml-schema.json
@@ -1,8 +1,8 @@
 {
-    "$id": "customPermission-meta-xml-schema",
+    "$id": "permissionset-meta-xml-schema",
     "type": "object",
     "properties": {
-        "CustomPermission": {
+        "PermissionSet": {
             "type": "object",
             "localizable": true,
             "localizableType": "string",
@@ -21,13 +21,20 @@
                         }
                     }
                 },
-                "description": {
+                "objectPermissions": {
                     "type": "object",
+                    "required": ["object"],
                     "properties": {
-                        "_text": {
-                            "type": "string",
-                            "localizableType": {
-                                "comment": "_value"
+                        "object": {
+                            "type": "object",
+                            "required": ["_text"],
+                            "properties": {
+                                "_text": {
+                                    "type": "string",
+                                    "localizableType": {
+                                        "context": "_value"
+                                    }
+                                }
                             }
                         }
                     }

--- a/schemas/quickAction-meta-xml-schema.json
+++ b/schemas/quickAction-meta-xml-schema.json
@@ -6,9 +6,11 @@
             "type": "object",
             "localizable": true,
             "localizableType": "string",
+            "required": ["label"],
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",

--- a/schemas/quickAction-meta-xml-schema.json
+++ b/schemas/quickAction-meta-xml-schema.json
@@ -1,0 +1,61 @@
+{
+    "$id": "quickAction-meta-xml-schema",
+    "type": "object",
+    "$defs": {
+        "entry-type": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value"
+                            }
+                        }
+                    }
+                },
+                "type": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "key": "_value"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "comment": "_value"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "properties": {
+        "QuickAction": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/entry-type"
+                    }
+                },
+                {
+                    "$ref": "#/$defs/entry-type"
+                }
+            ]
+        }
+    }
+}

--- a/schemas/quickAction-meta-xml-schema.json
+++ b/schemas/quickAction-meta-xml-schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "quickAction-meta-xml-schema",
+    "$id": "quickaction-meta-xml-schema",
     "type": "object",
     "$defs": {
         "entry-type": {
@@ -15,18 +15,8 @@
                         "_text": {
                             "type": "string",
                             "localizableType": {
-                                "source": "_value"
-                            }
-                        }
-                    }
-                },
-                "type": {
-                    "type": "object",
-                    "properties": {
-                        "_text": {
-                            "type": "string",
-                            "localizableType": {
-                                "key": "_value"
+                                "source": "_value",
+                                "key": "_basename"
                             }
                         }
                     }

--- a/schemas/translation-meta-xml-schema.json
+++ b/schemas/translation-meta-xml-schema.json
@@ -6,9 +6,11 @@
             "type": "object",
             "localizable": true,
             "localizableType": "string",
+            "required": ["label","name"],
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",
@@ -20,6 +22,7 @@
                 },
                 "name": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",
@@ -46,9 +49,11 @@
             "type": "object",
             "localizable": true,
             "localizableType": "string",
+            "required": ["label", "name"],
             "properties": {
                 "label": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",
@@ -60,6 +65,7 @@
                 },
                 "name": {
                     "type": "object",
+                    "required": ["_text"],
                     "properties": {
                         "_text": {
                             "type": "string",

--- a/schemas/translation-meta-xml-schema.json
+++ b/schemas/translation-meta-xml-schema.json
@@ -1,0 +1,132 @@
+{
+    "$id": "translation-meta-xml-schema",
+    "type": "object",
+    "$defs": {
+        "entry-type": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value"
+                            }
+                        }
+                    }
+                },
+                "name": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "key": "_value"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "comment": "_value"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "report-type": {
+            "type": "object",
+            "localizable": true,
+            "localizableType": "string",
+            "properties": {
+                "label": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "source": "_value"
+                            }
+                        }
+                    }
+                },
+                "name": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "key": "_value"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "object",
+                    "properties": {
+                        "_text": {
+                            "type": "string",
+                            "localizableType": {
+                                "comment": "_value"
+                            }
+                        }
+                    }
+                },
+                "sections": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/entry-type"
+                            }
+                        },
+                        {
+                            "$ref": "#/$defs/entry-type"
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "properties": {
+        "Translations": {
+            "type": "object",
+            "properties": {
+                "reportTypes": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/report-type"
+                            }
+                        },
+                        {
+                            "$ref": "#/$defs/report-type"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/entry-type"
+                        }
+                    },
+                    {
+                        "$ref": "#/$defs/entry-type"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/test/testMetaXmlFile.js
+++ b/test/testMetaXmlFile.js
@@ -24,11 +24,25 @@ if (!MetaXmlFile) {
     var MetaXmlFile = require("../MetaXmlFile.js");
     var MetaXmlFileType = require("../MetaXmlFileType.js");
     var CustomProject =  require("loctool/lib/CustomProject.js");
-    var ContextResourceString =  require("loctool/lib/ContextResourceString.js");
+    var ResourceString =  require("loctool/lib/ResourceString.js");
     var TranslationSet =  require("loctool/lib/TranslationSet.js");
 }
 
 function diff(a, b) {
+    if (!a && !b) return;
+    if (!a) {
+        console.log("Found difference at character 0");
+        console.log("a: undefined");
+        console.log("b: " + b.substring(i));
+        return;
+    }
+    if (!b) {
+        console.log("Found difference at character 0");
+        console.log("a: " + a.substring(i));
+        console.log("b: undefined");
+        return;
+    }
+
     var min = Math.min(a.length, b.length);
 
     for (var i = 0; i < min; i++) {
@@ -70,8 +84,6 @@ var p2 = new CustomProject({
 var t = new MetaXmlFileType(p2);
 
 module.exports.metaxmlfile = {
-    // make sure to initialize the file types so that the tests below can use
-    // a ContextResourceString instead of a regular ContextResourceString
     testMetaXmlInit: function(test) {
         p.init(function() {
             p2.init(function() {
@@ -84,7 +96,8 @@ module.exports.metaxmlfile = {
         test.expect(1);
 
         var mxf = new MetaXmlFile({
-            project: p
+            project: p,
+            type: mxft
         });
         test.ok(mxf);
 
@@ -304,7 +317,10 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyNewLines: function(test) {
         test.expect(2);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
         test.ok(mxf);
 
         // makeKey is used for double-quoted strings, which ruby interprets before it is used
@@ -316,7 +332,10 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyEscapeN: function(test) {
         test.expect(2);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
         test.ok(mxf);
 
         // makeKey is used for double-quoted strings, which ruby interprets before it is used
@@ -328,7 +347,11 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyTabs: function(test) {
         test.expect(2);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
+
         test.ok(mxf);
 
         test.equals(mxf.makeKey("A \t B"), "r191336864");
@@ -339,7 +362,11 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyEscapeT: function(test) {
         test.expect(2);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
+
         test.ok(mxf);
 
         test.equals(mxf.makeKey("A \\t B"), "r191336864");
@@ -350,7 +377,11 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyQuotes: function(test) {
         test.expect(2);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
+
         test.ok(mxf);
 
         test.equals(mxf.makeKey("A \\'B\\' C"), "r935639115");
@@ -361,7 +392,11 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyInterpretEscapedUnicodeChars: function(test) {
         test.expect(2);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
+
         test.ok(mxf);
 
         test.equals(mxf.makeKey("\\u00A0 \\u0023"), "r2293235");
@@ -372,7 +407,11 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyInterpretEscapedSpecialChars2: function(test) {
         test.expect(2);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
+
         test.ok(mxf);
 
         test.equals(mxf.makeKey("Talk to a support representative live 24/7 via video or \u00a0 text\u00a0chat"), "r969175354");
@@ -383,7 +422,11 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyInterpretEscapedOctalChars: function(test) {
         test.expect(2);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
+
         test.ok(mxf);
 
         test.equals(mxf.makeKey("A \\40 \\011 B"), "r191336864");
@@ -394,7 +437,11 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyMetaXmlEscapeSequences: function(test) {
         test.expect(2);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
+
         test.ok(mxf);
 
         test.equals(mxf.makeKey("A \\b\\t\\n\\f\\r B"), "r191336864");
@@ -405,7 +452,11 @@ module.exports.metaxmlfile = {
     testMetaXmlFileMakeKeyCheckRubyCompatibility: function(test) {
         test.expect(13);
 
-        var mxf = new MetaXmlFile({project: p});
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
+
         test.ok(mxf);
 
         test.equals(mxf.makeKey("This has \\\"double quotes\\\" in it."), "r487572481");
@@ -438,6 +489,38 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customApplications>\n' +
+            '        <label>Password</label>\n' +
+            '        <name>Test</name>\n' +
+            '    </customApplications>\n' +
+            '</Translations>\n'
+        );
+
+        var set = mxf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        test.ok(r);
+
+        test.equal(r.getSource(), "Password");
+        test.equal(r.getKey(), "Test");
+
+        test.done();
+    },
+
+    testMetaXmlFileParseCommentOnly: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: undefined,
+            type: mxft
+        });
+        test.ok(mxf);
+
+        mxf.parse(
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <customApplications>\n' +
             '        <label><!-- Password --></label>\n' +
             '        <name>Test</name>\n' +
             '    </customApplications>\n' +
@@ -447,17 +530,17 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "customApplications", "en-US", "Test", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
         test.ok(r);
 
-        test.equal(r.getSource(), "Password");
+        test.ok(!r.getSource());
         test.equal(r.getKey(), "Test");
 
         test.done();
     },
 
-    testMetaXmlFileParseIgnoreEmpty: function(test) {
-        test.expect(3);
+    testMetaXmlFileParseEmpty: function(test) {
+        test.expect(6);
 
         var mxf = new MetaXmlFile({
             project: p,
@@ -479,7 +562,13 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        test.equal(set.size(), 0);
+        test.equal(set.size(), 1);
+
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        test.ok(r);
+
+        test.ok(!r.getSource());
+        test.equal(r.getKey(), "Test");
 
         test.done();
     },
@@ -498,7 +587,7 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customApplications>\n' +
-            '        <label><!--    Enter Your Password \r \n  --></label>\n' +
+            '        <label>    Enter Your Password \r \n  </label>\n' +
             '        <name>Test</name>\n' +
             '    </customApplications>\n' +
             '</Translations>\n'
@@ -507,7 +596,7 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "customApplications", "en-US", "Test", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
         test.ok(r);
         test.equal(r.getSource(), "Enter Your Password");
         test.equal(r.getKey(), "Test");
@@ -532,7 +621,7 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customApplications>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customApplications>\n' +
             '</Translations>\n'
@@ -546,7 +635,7 @@ module.exports.metaxmlfile = {
     },
 
     testMetaXmlFileParseCustomApplications: function(test) {
-        test.expect(6);
+        test.expect(5);
 
         var mxf = new MetaXmlFile({
             project: p,
@@ -559,7 +648,7 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customApplications>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customApplications>\n' +
             '</Translations>\n'
@@ -568,18 +657,17 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "customApplications", "en-US", "Test", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
         test.equal(r.getKey(), "Test");
-        test.equal(r.getContext(), "customApplications");
 
         test.done();
     },
 
     testMetaXmlFileParseCustomLabels: function(test) {
-        test.expect(6);
+        test.expect(5);
 
         var mxf = new MetaXmlFile({
             project: p,
@@ -592,7 +680,7 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customLabels>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customLabels>\n' +
             '</Translations>\n'
@@ -601,18 +689,17 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "customLabels", "en-US", "Test", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
         test.equal(r.getKey(), "Test");
-        test.equal(r.getContext(), "customLabels");
 
         test.done();
     },
 
     testMetaXmlFileParseCustomTabs: function(test) {
-        test.expect(6);
+        test.expect(5);
 
         var mxf = new MetaXmlFile({
             project: p,
@@ -625,7 +712,7 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customTabs>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customTabs>\n' +
             '</Translations>\n'
@@ -634,22 +721,21 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "customTabs", "en-US", "Test", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
         test.equal(r.getKey(), "Test");
-        test.equal(r.getContext(), "customTabs");
 
         test.done();
     },
 
     testMetaXmlFileParseQuickActions: function(test) {
-        test.expect(6);
+        test.expect(5);
 
         var mxf = new MetaXmlFile({
             project: p,
-            pathName: undefined,
+            pathName: "force-app/main/default/translations/en-US.translation-meta.xml",
             type: mxft
         });
         test.ok(mxf);
@@ -658,7 +744,7 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <quickActions>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </quickActions>\n' +
             '</Translations>\n'
@@ -667,22 +753,21 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "quickActions", "en-US", "Test", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
         test.equal(r.getKey(), "Test");
-        test.equal(r.getContext(), "quickActions");
 
         test.done();
     },
 
     testMetaXmlFileParseReportTypes: function(test) {
-        test.expect(10);
+        test.expect(8);
 
         var mxf = new MetaXmlFile({
             project: p,
-            pathName: undefined,
+            pathName: "force-app/main/default/translations/en-US.translation-meta.xml",
             type: mxft
         });
         test.ok(mxf);
@@ -691,11 +776,11 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <reportTypes>\n' +
-            '        <label><!-- Screen Flows --></label>\n' +
+            '        <label>Screen Flows</label>\n' +
             '        <name>screen_flows_prebuilt_crt</name>\n' +
             '        <sections>\n' +
-            '            <label><!-- Flow Interview Log Entries --></label>\n' +
             '            <name>Test1</name>\n' +
+            '            <label>Flow Interview Log Entries</label>\n' +
             '        </sections>\n' +
             '    </reportTypes>\n' +
             '</Translations>\n'
@@ -704,29 +789,27 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "reportTypes", "en-US", "screen_flows_prebuilt_crt", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "screen_flows_prebuilt_crt", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Screen Flows");
         test.equal(r.getKey(), "screen_flows_prebuilt_crt");
-        test.equal(r.getContext(), "reportTypes");
 
-        r = set.get(ContextResourceString.hashKey("forceapp", "reportTypes.sections", "en-US", "screen_flows_prebuilt_crt.Test1", "metaxml"));
+        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test1", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Flow Interview Log Entries");
-        test.equal(r.getKey(), "screen_flows_prebuilt_crt.Test1");
-        test.equal(r.getContext(), "reportTypes.sections");
+        test.equal(r.getKey(), "Test1");
 
         test.done();
     },
 
     testMetaXmlFileParseReportTypesMultiple: function(test) {
-        test.expect(14);
+        test.expect(11);
 
         var mxf = new MetaXmlFile({
             project: p,
-            pathName: undefined,
+            pathName: "force-app/main/default/translations/en-US.translation-meta.xml",
             type: mxft
         });
         test.ok(mxf);
@@ -735,15 +818,15 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <reportTypes>\n' +
-            '        <description><!-- Screen Flows --></description>\n' +
-            '        <label><!-- Screen Flows --></label>\n' +
+            '        <description>Screen Flows</description>\n' +
+            '        <label>Screen Flows</label>\n' +
             '        <name>screen_flows_prebuilt_crt</name>\n' +
             '        <sections>\n' +
-            '            <label><!-- Flow Interview Log Entries --></label>\n' +
+            '            <label>Flow Interview Log Entries</label>\n' +
             '            <name>Test1</name>\n' +
             '        </sections>\n' +
             '        <sections>\n' +
-            '            <label><!-- Flow Interview Logs --></label>\n' +
+            '            <label>Flow Interview Logs</label>\n' +
             '            <name>Test2</name>\n' +
             '        </sections>\n' +
             '    </reportTypes>\n' +
@@ -753,26 +836,23 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "reportTypes", "en-US", "screen_flows_prebuilt_crt", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "screen_flows_prebuilt_crt", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Screen Flows");
         test.equal(r.getKey(), "screen_flows_prebuilt_crt");
-        test.equal(r.getContext(), "reportTypes");
 
-        r = set.get(ContextResourceString.hashKey("forceapp", "reportTypes.sections", "en-US", "screen_flows_prebuilt_crt.Test1", "metaxml"));
+        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test1", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Flow Interview Log Entries");
-        test.equal(r.getKey(), "screen_flows_prebuilt_crt.Test1");
-        test.equal(r.getContext(), "reportTypes.sections");
+        test.equal(r.getKey(), "Test1");
 
-        r = set.get(ContextResourceString.hashKey("forceapp", "reportTypes.sections", "en-US", "screen_flows_prebuilt_crt.Test2", "metaxml"));
+        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test2", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Flow Interview Logs");
-        test.equal(r.getKey(), "screen_flows_prebuilt_crt.Test2");
-        test.equal(r.getContext(), "reportTypes.sections");
+        test.equal(r.getKey(), "Test2");
 
         test.done();
     },
@@ -782,7 +862,7 @@ module.exports.metaxmlfile = {
 
         var mxf = new MetaXmlFile({
             project: p,
-            pathName: undefined,
+            pathName: "force-app/main/default/translations/en-US.translation-meta.xml",
             type: mxft
         });
         test.ok(mxf);
@@ -791,15 +871,15 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <reportTypes>\n' +
-            '        <description><!-- Screen Flows --></description>\n' +
-            '        <label><!-- Screen Flows --></label>\n' +
+            '        <description>Screen Flows</description>\n' +
+            '        <label>Screen Flows</label>\n' +
             '        <name>screen_flows_prebuilt_crt</name>\n' +
             '        <sections>\n' +
-            '            <label><!-- Flow Interview Log Entries --></label>\n' +
+            '            <label>Flow Interview Log Entries</label>\n' +
             '            <name>Test1</name>\n' +
             '        </sections>\n' +
             '        <sections>\n' +
-            '            <label><!-- Flow Interview Logs --></label>\n' +
+            '            <label>Flow Interview Logs</label>\n' +
             '            <name>Test2</name>\n' +
             '        </sections>\n' +
             '    </reportTypes>\n' +
@@ -809,17 +889,17 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        test.equal(set.size(), 4);
+        test.equal(set.size(), 3);
 
         test.done();
     },
 
     testMetaXmlFileParseReportTypesWithDescription: function(test) {
-        test.expect(14);
+        test.expect(9);
 
         var mxf = new MetaXmlFile({
             project: p,
-            pathName: undefined,
+            pathName: "force-app/main/default/translations/en-US.translation-meta.xml",
             type: mxft
         });
         test.ok(mxf);
@@ -828,11 +908,11 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <reportTypes>\n' +
-            '        <description><!-- Screen Flows Description --></description>\n' +
-            '        <label><!-- Screen Flows --></label>\n' +
+            '        <description>Screen Flows Description</description>\n' +
+            '        <label>Screen Flows</label>\n' +
             '        <name>screen_flows_prebuilt_crt</name>\n' +
             '        <sections>\n' +
-            '            <label><!-- Flow Interview Log Entries --></label>\n' +
+            '            <label>Flow Interview Log Entries</label>\n' +
             '            <name>Test1</name>\n' +
             '        </sections>\n' +
             '    </reportTypes>\n' +
@@ -842,36 +922,28 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "reportTypes", "en-US", "screen_flows_prebuilt_crt", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "screen_flows_prebuilt_crt", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Screen Flows");
         test.equal(r.getKey(), "screen_flows_prebuilt_crt");
-        test.equal(r.getContext(), "reportTypes");
+        test.equal(r.getComment(), "Screen Flows Description");
 
-        r = set.get(ContextResourceString.hashKey("forceapp", "reportTypes", "en-US", "screen_flows_prebuilt_crt.description", "metaxml"));
-        test.ok(r);
-
-        test.equal(r.getSource(), "Screen Flows Description");
-        test.equal(r.getKey(), "screen_flows_prebuilt_crt.description");
-        test.equal(r.getContext(), "reportTypes");
-
-        r = set.get(ContextResourceString.hashKey("forceapp", "reportTypes.sections", "en-US", "screen_flows_prebuilt_crt.Test1", "metaxml"));
+        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test1", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Flow Interview Log Entries");
-        test.equal(r.getKey(), "screen_flows_prebuilt_crt.Test1");
-        test.equal(r.getContext(), "reportTypes.sections");
+        test.equal(r.getKey(), "Test1");
 
         test.done();
     },
 
     testMetaXmlFileParseWithDups: function(test) {
-        test.expect(7);
+        test.expect(6);
 
         var mxf = new MetaXmlFile({
             project: p,
-            pathName: undefined,
+            pathName: "force-app/main/default/translations/en-US.translation-meta.xml",
             type: mxft
         });
         test.ok(mxf);
@@ -880,11 +952,11 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customLabels>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customLabels>\n' +
             '    <customLabels>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customLabels>\n' +
             '</Translations>\n'
@@ -893,12 +965,11 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "customLabels", "en-US", "Test", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
         test.equal(r.getKey(), "Test");
-        test.equal(r.getContext(), "customLabels");
 
         test.equal(set.size(), 1);
 
@@ -906,11 +977,11 @@ module.exports.metaxmlfile = {
     },
 
     testMetaXmlFileParseWithDupsWithDifferentKeys: function(test) {
-        test.expect(11);
+        test.expect(9);
 
         var mxf = new MetaXmlFile({
             project: p,
-            pathName: undefined,
+            pathName: "force-app/main/default/translations/en-US.translation-meta.xml",
             type: mxft
         });
         test.ok(mxf);
@@ -919,11 +990,11 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customLabels>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test1</name>\n' +
             '    </customLabels>\n' +
             '    <customLabels>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test2</name>\n' +
             '    </customLabels>\n' +
             '</Translations>\n'
@@ -932,27 +1003,70 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "customLabels", "en-US", "Test1", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test1", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
         test.equal(r.getKey(), "Test1");
-        test.equal(r.getContext(), "customLabels");
 
-        r = set.get(ContextResourceString.hashKey("forceapp", "customLabels", "en-US", "Test2", "metaxml"));
+        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test2", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
         test.equal(r.getKey(), "Test2");
-        test.equal(r.getContext(), "customLabels");
 
         test.equal(set.size(), 2);
 
         test.done();
     },
 
+
+    testMetaXmlFileParseCustomApplication: function(test) {
+        test.expect(11);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "foo/bar/foo.app-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        mxf.parse(
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <defaultLandingTab>x</defaultLandingTab>\n' +
+            '    <description>Screen Flows Description</description>\n' +
+            '    <isNavAutoTempTabsDisabled>false</isNavAutoTempTabsDisabled>\n' +
+            '    <isNavPersonalizationDisabled>false</isNavPersonalizationDisabled>\n' +
+            '    <label>Screen Flows</label>\n' +
+            '    <logo>screen_flow.png</logo>\n' +
+            '    <tabs>x</tabs>\n' +
+            '    <tabs>y</tabs>\n' +
+            '    <tabs>z</tabs>\n' +
+            '</CustomApplication>\n'
+        );
+
+        var set = mxf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 1);
+
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Screen Flows", "xml"));
+        test.ok(r);
+
+        test.equal(r.getSource(), "Screen Flows");
+        test.equal(r.getKey(), "Screen Flows");
+        test.equal(r.getComment(), "Screen Flows Description");
+        test.equal(r.getSourceLocale(), "en-US");
+        test.equal(r.getType(), "string");
+        test.ok(!r.getTarget());
+        test.ok(!r.getTargetLocale());
+
+        test.done();
+    },
+
     testMetaXmlFileExtractFile: function(test) {
-        test.expect(14);
+        test.expect(11);
 
         var mxf = new MetaXmlFile({
             project: p,
@@ -966,25 +1080,22 @@ module.exports.metaxmlfile = {
 
         var set = mxf.getTranslationSet();
 
-        test.equal(set.size(), 9);
+        test.equal(set.size(), 8);
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "customApplications", "en-US", "Test", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
         test.ok(r);
-        test.equal(r.getSource(), "Test");
+        test.ok(!r.getSource());
         test.equal(r.getKey(), "Test");
-        test.equal(r.getContext(), "customApplications");
 
-        r = set.get(ContextResourceString.hashKey("forceapp", "customApplications", "en-US", "Force_com", "metaxml"));
+        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Force_com", "xml"));
         test.ok(r);
-        test.equal(r.getSource(), "Force.com");
+        test.ok(!r.getSource());
         test.equal(r.getKey(), "Force_com");
-        test.equal(r.getContext(), "customApplications");
 
-        var r = set.get(ContextResourceString.hashKey("forceapp", "reportTypes.sections", "en-US", "screen_flows_prebuilt_crt.Flow Interview Log Entries", "metaxml"));
+        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Flow Interview Log Entries", "xml"));
         test.ok(r);
-        test.equal(r.getSource(), "Flow Interview Log Entries");
-        test.equal(r.getKey(), "screen_flows_prebuilt_crt.Flow Interview Log Entries");
-        test.equal(r.getContext(), "reportTypes.sections");
+        test.ok(!r.getSource());
+        test.equal(r.getKey(), "Flow Interview Log Entries");
 
         test.done();
     },
@@ -1158,20 +1269,20 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customApplications>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customApplications>\n' +
             '</Translations>\n'
         );
 
         var translations = new TranslationSet();
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Password',
             target: 'Passwort',
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customApplications"
         }));
 
@@ -1208,20 +1319,20 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customApplications>\n' +
-            '        <label><!-- Password <name> &uuml; --></label>\n' +
+            '        <label>Password &lt;name> &uuml;</label>\n' +
             '        <name>Test</name>\n' +
             '    </customApplications>\n' +
             '</Translations>\n'
         );
 
         var translations = new TranslationSet();
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Password <name> &uuml;',
             target: 'Passwort <name> &uuml;',
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customApplications"
         }));
 
@@ -1258,7 +1369,7 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <reportTypes>\n' +
-            '        <description><!-- Screen Flows Description --></description>\n' +
+            '        <description>Screen Flows Description</description>\n' +
             '        <label>Coule d\'écran</label>\n' +
             '        <name>screen_flows_prebuilt_crt</name>\n' +
             '        <sections>\n' +
@@ -1270,31 +1381,31 @@ module.exports.metaxmlfile = {
         );
 
         var translations = new TranslationSet();
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt',
             source: 'Screen Flows',
             target: "Coule d'écran",
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.description',
             source: 'Screen Flows Description',
             target: "Description de coule d'écran",
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.Flow Interview Log Entries',
             source: 'Flow Interview Log Entries',
             target: "Entrées de journal pour coule de entretien",
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes.sections"
         }));
 
@@ -1336,167 +1447,167 @@ module.exports.metaxmlfile = {
         mxf.extract();
 
         var translations = new TranslationSet();
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Test',
             target: 'Testez',
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customApplications"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Force_com',
             source: 'Force.com',
             target: 'Force.fr',
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customApplications"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Account',
             source: 'Text Account',
             target: 'Compte de texte',
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customLabels"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Files2',
             source: 'Files online',
             target: 'Fichiers en ligne',
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customTabs"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'LogACall',
             source: 'LogACall',
             target: 'EnregistrerUnAppel',
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "quickActions"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt',
             source: 'Screen Flows',
             target: "Coule d'écran",
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.description',
             source: 'Screen Flows Description',
             target: "Description de coule d'écran",
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.Flow Interview Log Entries',
             source: 'Flow Interview Log Entries',
             target: "Entrées de journal pour coule de entretien",
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes.sections"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.Flow Interview Logs',
             source: 'Flow Interview Logs',
             target: "Journals pour coule de entretien",
             targetLocale: "fr-FR",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes.sections"
         }));
 
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Test',
             target: 'Testen',
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customApplications"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Force_com',
             source: 'Force.com',
             target: 'Force.de',
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customApplications"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Account',
             source: 'Text Account',
             target: 'Texteskonto',
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customLabels"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'Files2',
             source: 'Files online',
             target: 'Dateien online',
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customTabs"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'LogACall',
             source: 'LogACall',
             target: 'EinenAnrufProtokollieren',
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "quickActions"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt',
             source: 'Screen Flows',
             target: "Bildschirmsflussen",
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.description',
             source: 'Screen Flows Description',
             target: "Beschreibung des Bildschirmsflussen",
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.Flow Interview Log Entries',
             source: 'Flow Interview Log Entries',
             target: "Protokolleinträge von Flussinterviews",
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes.sections"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.Flow Interview Logs',
             source: 'Flow Interview Logs',
             target: "Protokollen von Flussinterviews",
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "reportTypes.sections"
         }));
 
@@ -1621,28 +1732,28 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customApplications>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customApplications>\n' +
             '</Translations>\n'
         );
 
         var translations = new TranslationSet();
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'r308704783',
             source: 'Get insurance quotes for free!',
             target: 'Obtenez des devis d\'assurance gratuitement!',
             targetLocale: "fr-FR",
-            datatype: "metaxml"
+            datatype: "xml"
         }));
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'r308704783',
             source: 'Get insurance quotes for free!',
             target: 'Kostenlosen Versicherungs-Angebote erhalten!',
             targetLocale: "de-DE",
-            datatype: "metaxml"
+            datatype: "xml"
         }));
 
         mxf.localize(translations, ["fr-FR", "de-DE"]);
@@ -1671,20 +1782,20 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customApplications>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customApplications>\n' +
             '</Translations>\n'
         );
 
         var translations = new TranslationSet();
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'foo',
             source: 'bar',
             target: 'asdf',
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customApplications"
         }));
 
@@ -1744,20 +1855,20 @@ module.exports.metaxmlfile = {
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
             '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
             '    <customApplications>\n' +
-            '        <label><!-- Password --></label>\n' +
+            '        <label>Password</label>\n' +
             '        <name>Test</name>\n' +
             '    </customApplications>\n' +
             '</Translations>\n'
         );
 
         var translations = new TranslationSet();
-        translations.add(new ContextResourceString({
+        translations.add(new ResourceString({
             project: "forceapp",
             key: 'foo',
             source: 'bar',
             target: 'asdf',
             targetLocale: "de-DE",
-            datatype: "metaxml",
+            datatype: "xml",
             context: "customLabels"
         }));
 

--- a/test/testMetaXmlFile.js
+++ b/test/testMetaXmlFile.js
@@ -79,13 +79,13 @@ var p2 = new CustomProject({
 }, "./test/testfiles", {
     locales:["en-GB"],
     identify: true,
-    targetDir: "testfiles",
+    nopseudo: true,
     metaxml: {
         resourceFile: "force-app/main/default/translations/[localeUnder].translation-meta.xml"
     }
 });
 
-var t = new MetaXmlFileType(p2);
+var mxft2 = new MetaXmlFileType(p2);
 
 module.exports.metaxmlfile = {
     testMetaXmlInit: function(test) {
@@ -1144,7 +1144,7 @@ module.exports.metaxmlfile = {
     },
 
     testMetaXmlFileExtractLabelsFile: function(test) {
-        test.expect(8);
+        test.expect(10);
 
         var mxf = new MetaXmlFile({
             project: p,
@@ -1164,11 +1164,13 @@ module.exports.metaxmlfile = {
         test.ok(r);
         test.equal(r.getSource(), "Show Sender in Recipient List");
         test.equal(r.getKey(), "Show_Sender_in_Recipient_List");
+        test.equal(r.getComment(), "Whether or not the sender should be shown in the recipient list of the email.");
 
         r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test_of_emergency_warning_system", "xml"));
         test.ok(r);
         test.equal(r.getSource(), "Test of the emergency warning system.");
         test.equal(r.getKey(), "Test_of_emergency_warning_system");
+        test.equal(r.getComment(), "Had this been a real test, you would have been instructed to calmly leave the building.");
 
         test.done();
     },
@@ -2312,7 +2314,7 @@ module.exports.metaxmlfile = {
     },
 */
 
-    testMetaXmlFileLocalizeWithNoSourceStrings: function(test) {
+    testMetaXmlFileLocalizeWrite: function(test) {
         test.expect(5);
 
         var base = path.dirname(module.id);
@@ -2354,7 +2356,7 @@ module.exports.metaxmlfile = {
         }));
         translations.add(new ContextResourceString({
             project: "forceapp",
-            key: 'AcessToken_Expr__c',
+            key: 'AccessToken_Expr__c',
             source: '',
             target: 'Jetons d\'accès',
             targetLocale: "fr-FR",
@@ -2467,7 +2469,7 @@ module.exports.metaxmlfile = {
         }));
         translations.add(new ContextResourceString({
             project: "forceapp",
-            key: 'AcessToken_Expr__c',
+            key: 'AccessToken_Expr__c',
             source: '',
             target: 'Zugriffstoken',
             targetLocale: "de-DE",
@@ -2580,7 +2582,7 @@ module.exports.metaxmlfile = {
             '    </customApplications>\n' +
             '    <customField>\n' +
             '        <label>Jetons d\'accès</label>\n' +
-            '        <name>AcessToken_Expr__c</name>\n' +
+            '        <name>AccessToken_Expr__c</name>\n' +
             '    </customField>\n' +
             '    <customField>\n' +
             '        <label>Statut d\'attribution</label>\n' +
@@ -2642,7 +2644,7 @@ module.exports.metaxmlfile = {
             '    </customApplications>\n' +
             '    <customField>\n' +
             '        <label>Zugriffstoken</label>\n' +
-            '        <name>AcessToken_Expr__c</name>\n' +
+            '        <name>AccessToken_Expr__c</name>\n' +
             '    </customField>\n' +
             '    <customField>\n' +
             '        <label>Zuordnungsstatus</label>\n' +
@@ -2696,29 +2698,388 @@ module.exports.metaxmlfile = {
         test.done();
     },
 
-/*
+    testMetaXmlFileLocalizeWithNoSourceStrings: function(test) {
+        test.expect(5);
+
+        var base = path.dirname(module.id);
+
+        var mxf = mxft.newFile("./force-app/main/default/translations/en_US.translation-meta.xml");
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp',
+            source: '',
+            target: 'MonApp',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'AccessToken_Expr__c',
+            source: '',
+            target: 'Jetons d\'accès',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Allocation_status__c',
+            source: '',
+            target: 'Statut d\'attribution',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Collaboration__c',
+            source: '',
+            target: 'Collaborations',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Retry_Count__c',
+            source: '',
+            target: 'Nombre de tentatives',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Show_Sender_in_Recipient_List',
+            source: '',
+            target: 'Afficher l\'expéditeur dans la liste des destinataires',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Test_of_emergency_warning_system',
+            source: '',
+            target: 'Test du système d\'accès d\'urgence',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'String_only_in_translations_meta_xml',
+            source: 'Translations Only String',
+            target: 'Chaîne qui se trouve uniquement dans les traductions',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp_Files2',
+            source: '',
+            target: 'Onglet Fichiers',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'LogACall',
+            source: '',
+            target: 'EnregistrerUnAppel',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt',
+            source: '',
+            target: "Coule d'écran",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt.description',
+            source: '',
+            target: "Description de coule d'écran",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Log Entries',
+            source: '',
+            target: "Entrées de journal pour coule de entretien",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Logs',
+            source: '',
+            target: "Journals pour coule de entretien",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp',
+            source: '',
+            target: 'MeineApp',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'AccessToken_Expr__c',
+            source: '',
+            target: 'Zugriffstoken',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Allocation_status__c',
+            source: '',
+            target: 'Zuordnungsstatus',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Collaboration__c',
+            source: '',
+            target: 'Zusammenarbeit',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Retry_Count__c',
+            source: '',
+            target: 'Anzahl der Wiederholungen',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Show_Sender_in_Recipient_List',
+            source: '',
+            target: 'Den Absender in der Empfängerliste anzeigen',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Test_of_emergency_warning_system',
+            source: '',
+            target: 'Test des Notzugangssystems',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'String_only_in_translations_meta_xml',
+            source: 'Translations Only String',
+            target: 'String, der nur in den Übersetzungen vorkommt',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp_Files2',
+            source: '',
+            target: 'Registerkarte Dateien',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'LogACall',
+            source: '',
+            target: 'Anruf protokollieren',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt',
+            source: 'Screen Flows',
+            target: "Bildschirmsflussen",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Log Entries',
+            source: 'Flow Interview Log Entries',
+            target: "Protokolleinträge von Flussinterviews",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Logs',
+            source: 'Flow Interview Logs',
+            target: "Protokollen von Flussinterviews",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+
+        // now cause the localization by asking the filetype object to write
+        // out all of them. This should work despite the lack of source strings.
+        mxft.write(translations, ["fr-FR", "de-DE"]);
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/force-app/main/default/translations/fr.translation-meta.xml")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/force-app/main/default/translations/de.translation-meta.xml")));
+
+        var content = fs.readFileSync(path.join(base, "testfiles/force-app/main/default/translations/fr.translation-meta.xml"), "UTF-8");
+
+        var expected =
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <customApplications>\n' +
+            '        <label>MonApp</label>\n' +
+            '        <name>MyApp</name>\n' +
+            '    </customApplications>\n' +
+            '    <customField>\n' +
+            '        <label>Jetons d\'accès</label>\n' +
+            '        <name>AccessToken_Expr__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Statut d\'attribution</label>\n' +
+            '        <name>Allocation_status__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Collaborations</label>\n' +
+            '        <name>Collaboration__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Nombre de tentatives</label>\n' +
+            '        <name>Retry_Count__c</name>\n' +
+            '    </customField>\n' +
+            '    <customLabels>\n' +
+            '        <label>Afficher l\'expéditeur dans la liste des destinataires</label>\n' +
+            '        <name>Show_Sender_in_Recipient_List</name>\n' +
+            '    </customLabels>\n' +
+            '    <customLabels>\n' +
+            '        <label>Test du système d\'accès d\'urgence</label>\n' +
+            '        <name>Test_of_emergency_warning_system</name>\n' +
+            '    </customLabels>\n' +
+            '    <customLabels>\n' +
+            '        <label>Chaîne qui se trouve uniquement dans les traductions</label>\n' +
+            '        <name>String_only_in_translations_meta_xml</name>\n' +
+            '    </customLabels>\n' +
+            '    <customTabs>\n' +
+            '        <label>Onglet Fichiers</label>\n' +
+            '        <name>MyApp_Files2</name>\n' +
+            '    </customTabs>\n' +
+            '    <quickActions>\n' +
+            '        <label>EnregistrerUnAppel</label>\n' +
+            '        <name>LogACall</name>\n' +
+            '    </quickActions>\n' +
+            '    <reportTypes>\n' +
+            '        <label>Coule d\'écran</label>\n' +
+            '        <name>screen_flows_prebuilt_crt</name>\n' +
+            '        <sections>\n' +
+            '            <label>Entrées de journal pour coule de entretien</label>\n' +
+            '            <name>Flow Interview Log Entries</name>\n' +
+            '        </sections>\n' +
+            '        <sections>\n' +
+            '            <label>Journals pour coule de entretien</label>\n' +
+            '            <name>Flow Interview Logs</name>\n' +
+            '        </sections>\n' +
+            '    </reportTypes>\n' +
+            '</Translations>\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        content = fs.readFileSync(path.join(base, "testfiles/force-app/main/default/translations/de.translation-meta.xml"), "UTF-8");
+
+        var expected =
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <customApplications>\n' +
+            '        <label>MeineApp</label>\n' +
+            '        <name>MyApp</name>\n' +
+            '    </customApplications>\n' +
+            '    <customField>\n' +
+            '        <label>Zugriffstoken</label>\n' +
+            '        <name>AccessToken_Expr__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Zuordnungsstatus</label>\n' +
+            '        <name>Allocation_status__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Zusammenarbeit</label>\n' +
+            '        <name>Collaboration__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Anzahl der Wiederholungen</label>\n' +
+            '        <name>Retry_Count__c</name>\n' +
+            '    </customField>\n' +
+            '    <customLabels>\n' +
+            '        <label>Den Absender in der Empfängerliste anzeigen</label>\n' +
+            '        <name>Show_Sender_in_Recipient_List</name>\n' +
+            '    </customLabels>\n' +
+            '    <customLabels>\n' +
+            '        <label>Test des Notzugangssystems</label>\n' +
+            '        <name>Test_of_emergency_warning_system</name>\n' +
+            '    </customLabels>\n' +
+            '    <customLabels>\n' +
+            '        <label>String, der nur in den Übersetzungen vorkommt</label>\n' +
+            '        <name>String_only_in_translations_meta_xml</name>\n' +
+            '    </customLabels>\n' +
+            '    <customTabs>\n' +
+            '        <label>Registerkarte Dateien</label>\n' +
+            '        <name>MyApp_Files2</name>\n' +
+            '    </customTabs>\n' +
+            '    <quickActions>\n' +
+            '        <label>Anruf protokollieren</label>\n' +
+            '        <name>LogACall</name>\n' +
+            '    </quickActions>\n' +
+            '    <reportTypes>\n' +
+            '        <label>Bildschirmsflussen</label>\n' +
+            '        <name>screen_flows_prebuilt_crt</name>\n' +
+            '        <sections>\n' +
+            '            <label>Protokolleinträge von Flussinterviews</label>\n' +
+            '            <name>Flow Interview Log Entries</name>\n' +
+            '        </sections>\n' +
+            '        <sections>\n' +
+            '            <label>Protokollen von Flussinterviews</label>\n' +
+            '            <name>Flow Interview Logs</name>\n' +
+            '        </sections>\n' +
+            '    </reportTypes>\n' +
+            '</Translations>\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        test.done();
+    },
+
     testMetaXmlFileLocalizeNoStrings: function(test) {
         test.expect(5);
 
         var base = path.dirname(module.id);
 
-        var mxf = new MetaXmlFile({
-            project: p,
-            pathName: "./html/nostrings.html",
-            type: t
-        });
+        var mxf = mxft2.newFile("./xml/en-US.translation-meta.xml");
         test.ok(mxf);
 
         // set up
-        if (fs.existsSync(path.join(base, "./testfiles/html/de.translation-meta.xml"))) {
-            fs.unlinkSync(path.join(base, "./testfiles/html/de.translation-meta.xml"));
+        if (fs.existsSync(path.join(base, "testfiles/xml/de.translation-meta.xml"))) {
+            fs.unlinkSync(path.join(base, "testfiles/xml/de.translation-meta.xml"));
         }
-        if (fs.existsSync(path.join(base, "./testfiles/html/fr.translation-meta.xml"))) {
-            fs.unlinkSync(path.join(base, "./testfiles/html/fr.translation-meta.xml"));
+        if (fs.existsSync(path.join(base, "testfiles/xml/fr.translation-meta.xml"))) {
+            fs.unlinkSync(path.join(base, "testfiles/xml/fr.translation-meta.xml"));
         }
 
-        test.ok(!fs.existsSync(path.join(base, "./testfiles/html/de.translation-meta.xml")));
-        test.ok(!fs.existsSync(path.join(base, "./testfiles/html/fr.translation-meta.xml")));
+        test.ok(!fs.existsSync(path.join(base, "testfiles/xml/de.translation-meta.xml")));
+        test.ok(!fs.existsSync(path.join(base, "testfiles/xml/fr.translation-meta.xml")));
 
         mxf.parse(
             '<?xml version="1.0" encoding="UTF-8"?>\n' +
@@ -2731,6 +3092,7 @@ module.exports.metaxmlfile = {
         );
 
         var translations = new TranslationSet();
+        // some other translations that don't apply to the file above
         translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'r308704783',
@@ -2748,11 +3110,498 @@ module.exports.metaxmlfile = {
             datatype: "xml"
         }));
 
-        mxf.localize(translations, ["fr-FR", "de-DE"]);
+        mxft2.write(translations, ["fr-FR", "de-DE"]);
 
         // should produce the files, even if there is nothing to localize in them
-        test.ok(fs.existsSync(path.join(base, "./testfiles/html/de.translation-meta.xml")));
-        test.ok(fs.existsSync(path.join(base, "./testfiles/html/fr.translation-meta.xml")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/xml/de.translation-meta.xml")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/xml/fr.translation-meta.xml")));
+
+        if (fs.existsSync(path.join(base, "testfiles/xml/de.translation-meta.xml"))) {
+            fs.unlinkSync(path.join(base, "testfiles/xml/de.translation-meta.xml"));
+        }
+        if (fs.existsSync(path.join(base, "testfiles/xml/fr.translation-meta.xml"))) {
+            fs.unlinkSync(path.join(base, "testfiles/xml/fr.translation-meta.xml"));
+        }
+
+        test.done();
+    },
+
+    testMetaXmlFileLocalizeNewStringsNoSources: function(test) {
+        test.expect(26);
+
+        var base = path.dirname(module.id);
+
+        // clear the existing files and strings first
+        mxft.files = {};
+        var newStrings = mxft.getNew();
+        newStrings.clear();
+        test.equal(newStrings.size(), 0);
+
+        var mxf = mxft.newFile("./force-app/main/default/translations/en_US.translation-meta.xml");
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Collaboration__c',
+            source: '',
+            target: 'Collaborations',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Retry_Count__c',
+            source: '',
+            target: 'Nombre de tentatives',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Show_Sender_in_Recipient_List',
+            source: '',
+            target: 'Afficher l\'expéditeur dans la liste des destinataires',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Test_of_emergency_warning_system',
+            source: '',
+            target: 'Test du système d\'accès d\'urgence',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'String_only_in_translations_meta_xml',
+            source: 'Translations Only String',
+            target: 'Chaîne qui se trouve uniquement dans les traductions',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp_Files2',
+            source: '',
+            target: 'Onglet Fichiers',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'LogACall',
+            source: '',
+            target: 'EnregistrerUnAppel',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt',
+            source: '',
+            target: "Coule d'écran",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt.description',
+            source: '',
+            target: "Description de coule d'écran",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Log Entries',
+            source: '',
+            target: "Entrées de journal pour coule de entretien",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Logs',
+            source: '',
+            target: "Journals pour coule de entretien",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Collaboration__c',
+            source: '',
+            target: 'Zusammenarbeit',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Retry_Count__c',
+            source: '',
+            target: 'Anzahl der Wiederholungen',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Show_Sender_in_Recipient_List',
+            source: '',
+            target: 'Den Absender in der Empfängerliste anzeigen',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Test_of_emergency_warning_system',
+            source: '',
+            target: 'Test des Notzugangssystems',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'String_only_in_translations_meta_xml',
+            source: 'Translations Only String',
+            target: 'String, der nur in den Übersetzungen vorkommt',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp_Files2',
+            source: '',
+            target: 'Registerkarte Dateien',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'LogACall',
+            source: '',
+            target: 'Anruf protokollieren',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt',
+            source: 'Screen Flows',
+            target: "Bildschirmsflussen",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Log Entries',
+            source: 'Flow Interview Log Entries',
+            target: "Protokolleinträge von Flussinterviews",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Logs',
+            source: 'Flow Interview Logs',
+            target: "Protokollen von Flussinterviews",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+
+        // now cause the localization by asking the filetype object to write
+        // out all of them. This should work despite the lack of source strings.
+        mxft.write(translations, ["fr-FR", "de-DE"]);
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/force-app/main/default/translations/fr.translation-meta.xml")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/force-app/main/default/translations/de.translation-meta.xml")));
+
+        newStrings = mxft.getNew();
+        test.ok(newStrings);
+        test.equal(newStrings.size(), 6);
+
+        var resources = newStrings.getAll();
+        test.ok(resources);
+        test.equal(resources.length, 6);
+
+        test.equal(resources[0].getKey(), "MyApp");
+        test.ok(!resources[0].getSource());
+        test.equal(resources[0].getTargetLocale(), "fr-FR");
+
+        test.equal(resources[1].getKey(), "AccessToken_Expr__c");
+        test.ok(!resources[1].getSource());
+        test.equal(resources[1].getTargetLocale(), "fr-FR");
+
+        test.equal(resources[2].getKey(), "Allocation_status__c");
+        test.ok(!resources[2].getSource());
+        test.equal(resources[2].getTargetLocale(), "fr-FR");
+
+        test.equal(resources[3].getKey(), "MyApp");
+        test.ok(!resources[3].getSource());
+        test.equal(resources[3].getTargetLocale(), "de-DE");
+
+        test.equal(resources[4].getKey(), "AccessToken_Expr__c");
+        test.ok(!resources[4].getSource());
+        test.equal(resources[4].getTargetLocale(), "de-DE");
+
+        test.equal(resources[5].getKey(), "Allocation_status__c");
+        test.ok(!resources[5].getSource());
+        test.equal(resources[5].getTargetLocale(), "de-DE");
+
+        test.done();
+    },
+
+    testMetaXmlFileLocalizeNewStringsWithSources: function(test) {
+        test.expect(26);
+
+        var base = path.dirname(module.id);
+
+        // clear the existing files and strings first
+        mxft.files = {};
+        var newStrings = mxft.getNew();
+        newStrings.clear();
+        test.equal(newStrings.size(), 0);
+
+        var mxf = mxft.newFile("./force-app/main/default/translations/en_US.translation-meta.xml");
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        // now read the other xml files to find the source strings
+        [
+            "./force-app/all/labels/MyLabels.labels-meta.xml",
+            "./force-app/main/default/application/MyApp.app-meta.xml",
+            "./force-app/main/default/customMetadata/MyApp_Setting.Default_Configuration.md-meta.xml",
+            "./force-app/main/default/customPermissions/MyApp_Admin.customPermissions-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/AccessToken_Expr__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/Allocation_status__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/Collaboration__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/Retry_Count__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/listviews/ListView.listView-meta.xml",
+            "./force-app/main/default/objects/Foo__c/Foo__c.object-meta.xml",
+            "./force-app/main/default/quickActions/SendEmail.quickAction-meta.xml",
+            "./force-app/main/default/tabs/MyApp_Files2.tab-meta.xml"
+        ].forEach(function(pathName) {
+            var sourceXml = mxft.newFile(pathName);
+            sourceXml.extract();
+            mxf.addSet(sourceXml.getTranslationSet());
+        });
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Collaboration__c',
+            source: '',
+            target: 'Collaborations',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Retry_Count__c',
+            source: '',
+            target: 'Nombre de tentatives',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Show_Sender_in_Recipient_List',
+            source: '',
+            target: 'Afficher l\'expéditeur dans la liste des destinataires',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Test_of_emergency_warning_system',
+            source: '',
+            target: 'Test du système d\'accès d\'urgence',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'String_only_in_translations_meta_xml',
+            source: 'Translations Only String',
+            target: 'Chaîne qui se trouve uniquement dans les traductions',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp_Files2',
+            source: '',
+            target: 'Onglet Fichiers',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'LogACall',
+            source: '',
+            target: 'EnregistrerUnAppel',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt',
+            source: '',
+            target: "Coule d'écran",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt.description',
+            source: '',
+            target: "Description de coule d'écran",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Log Entries',
+            source: '',
+            target: "Entrées de journal pour coule de entretien",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Logs',
+            source: '',
+            target: "Journals pour coule de entretien",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Collaboration__c',
+            source: '',
+            target: 'Zusammenarbeit',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Retry_Count__c',
+            source: '',
+            target: 'Anzahl der Wiederholungen',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Show_Sender_in_Recipient_List',
+            source: '',
+            target: 'Den Absender in der Empfängerliste anzeigen',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Test_of_emergency_warning_system',
+            source: '',
+            target: 'Test des Notzugangssystems',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'String_only_in_translations_meta_xml',
+            source: 'Translations Only String',
+            target: 'String, der nur in den Übersetzungen vorkommt',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp_Files2',
+            source: '',
+            target: 'Registerkarte Dateien',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'LogACall',
+            source: '',
+            target: 'Anruf protokollieren',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt',
+            source: 'Screen Flows',
+            target: "Bildschirmsflussen",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Log Entries',
+            source: 'Flow Interview Log Entries',
+            target: "Protokolleinträge von Flussinterviews",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Logs',
+            source: 'Flow Interview Logs',
+            target: "Protokollen von Flussinterviews",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+
+        // now cause the localization by asking the filetype object to write
+        // out all of them. This should work despite the lack of source strings.
+        mxft.write(translations, ["fr-FR", "de-DE"]);
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/force-app/main/default/translations/fr.translation-meta.xml")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/force-app/main/default/translations/de.translation-meta.xml")));
+
+        newStrings = mxft.getNew();
+        test.ok(newStrings);
+        test.equal(newStrings.size(), 6);
+
+        var resources = newStrings.getAll();
+        test.ok(resources);
+        test.equal(resources.length, 6);
+
+        test.equal(resources[0].getKey(), "MyApp");
+        test.equal(resources[0].getSource(), "My Application");
+        test.equal(resources[0].getTargetLocale(), "fr-FR");
+
+        test.equal(resources[1].getKey(), "AccessToken_Expr__c");
+        test.equal(resources[1].getSource(), "Access token expired");
+        test.equal(resources[1].getTargetLocale(), "fr-FR");
+
+        test.equal(resources[2].getKey(), "Allocation_status__c");
+        test.equal(resources[2].getSource(), "Allocation status");
+        test.equal(resources[2].getTargetLocale(), "fr-FR");
+
+        test.equal(resources[3].getKey(), "MyApp");
+        test.equal(resources[3].getSource(), "My Application");
+        test.equal(resources[3].getTargetLocale(), "de-DE");
+
+        test.equal(resources[4].getKey(), "AccessToken_Expr__c");
+        test.equal(resources[4].getSource(), "Access token expired");
+        test.equal(resources[4].getTargetLocale(), "de-DE");
+
+        test.equal(resources[5].getKey(), "Allocation_status__c");
+        test.equal(resources[5].getSource(), "Allocation status");
+        test.equal(resources[5].getTargetLocale(), "de-DE");
 
         test.done();
     },
@@ -2762,9 +3611,9 @@ module.exports.metaxmlfile = {
 
         var base = path.dirname(module.id);
 
-        var mxft2 = new MetaXmlFileType(p);
+        var mxft2 = new MetaXmlFileType(p2);
         var mxf = new MetaXmlFile({
-            project: p,
+            project: p2,
             pathName: "./force-app/main/default/translations/en_US.translation-meta.xml",
             type: mxft2
         });
@@ -2838,7 +3687,7 @@ module.exports.metaxmlfile = {
         var t2 = new MetaXmlFileType(p3);
         var mxf = new MetaXmlFile({
             project: p3,
-            pathName: "./html/en.translation-meta.xml",
+            pathName: "./xml/en.translation-meta.xml",
             type: t2
         });
         test.ok(mxf);
@@ -2880,6 +3729,108 @@ module.exports.metaxmlfile = {
         test.equal(content, expected);
 
         test.done();
+    },
+
+    testMetaXmlFileLocalizeExtractedStringsWithSources: function(test) {
+        test.expect(17);
+
+        var base = path.dirname(module.id);
+
+        // clear the existing files and strings first
+        mxft.files = {};
+
+        var mxf = mxft.newFile("./force-app/main/default/translations/en_US.translation-meta.xml");
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        // now read the other xml files to find the source strings
+        [
+            "./force-app/all/labels/MyLabels.labels-meta.xml",
+            "./force-app/main/default/application/MyApp.app-meta.xml",
+            "./force-app/main/default/customMetadata/MyApp_Setting.Default_Configuration.md-meta.xml",
+            "./force-app/main/default/customPermissions/MyApp_Admin.customPermissions-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/AccessToken_Expr__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/Allocation_status__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/Collaboration__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/Retry_Count__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/listviews/ListView.listView-meta.xml",
+            "./force-app/main/default/objects/Foo__c/Foo__c.object-meta.xml",
+            "./force-app/main/default/quickActions/SendEmail.quickAction-meta.xml",
+            "./force-app/main/default/tabs/MyApp_Files2.tab-meta.xml"
+        ].forEach(function(pathName) {
+            var sourceXml = mxft.newFile(pathName);
+            sourceXml.extract();
+            mxf.addSet(sourceXml.getTranslationSet());
+        });
+
+        // there are 13 resources + 5 unused source strings from
+        // the other meta.xml files
+        extracted = mxf.getTranslationSet();
+        test.ok(extracted);
+        test.equal(extracted.size(), 18);
+
+        var resources = extracted.getAll();
+        test.ok(resources);
+        test.equal(resources.length, 18);
+
+        test.equal(resources[0].getKey(), "MyApp");
+        test.equal(resources[0].getSource(), "My Application");
+        test.equal(resources[0].getSourceLocale(), "en-US");
+        test.ok(!resources[0].getTargetLocale());
+
+        test.equal(resources[1].getKey(), "AccessToken_Expr__c");
+        test.equal(resources[1].getSource(), "Access token expired");
+        test.equal(resources[1].getSourceLocale(), "en-US");
+        test.ok(!resources[1].getTargetLocale());
+
+        test.equal(resources[2].getKey(), "Allocation_status__c");
+        test.equal(resources[2].getSource(), "Allocation status");
+        test.equal(resources[2].getSourceLocale(), "en-US");
+        test.ok(!resources[2].getTargetLocale());
+
+        test.done();
+    },
+
+    testMetaXmlFileLocalizeExtractedStringsWithoutSources: function(test) {
+        test.expect(17);
+
+        var base = path.dirname(module.id);
+
+        // clear the existing files and strings first
+        mxft.files = {};
+
+        var mxf = mxft.newFile("./force-app/main/default/translations/en_US.translation-meta.xml");
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        // there are 13 resources
+        extracted = mxf.getTranslationSet();
+        test.ok(extracted);
+        test.equal(extracted.size(), 13);
+
+        var resources = extracted.getAll();
+        test.ok(resources);
+        test.equal(resources.length, 13);
+
+        test.equal(resources[0].getKey(), "MyApp");
+        test.ok(!resources[0].getSource());
+        test.equal(resources[0].getSourceLocale(), "en-US");
+        test.ok(!resources[0].getTargetLocale());
+
+        test.equal(resources[1].getKey(), "AccessToken_Expr__c");
+        test.ok(!resources[1].getSource());
+        test.equal(resources[1].getSourceLocale(), "en-US");
+        test.ok(!resources[1].getTargetLocale());
+
+        test.equal(resources[2].getKey(), "Allocation_status__c");
+        test.ok(!resources[2].getSource());
+        test.equal(resources[2].getSourceLocale(), "en-US");
+        test.ok(!resources[2].getTargetLocale());
+
+        test.done();
     }
-*/
 };

--- a/test/testMetaXmlFile.js
+++ b/test/testMetaXmlFile.js
@@ -24,7 +24,8 @@ if (!MetaXmlFile) {
     var MetaXmlFile = require("../MetaXmlFile.js");
     var MetaXmlFileType = require("../MetaXmlFileType.js");
     var CustomProject =  require("loctool/lib/CustomProject.js");
-    var ResourceString =  require("loctool/lib/ResourceString.js");
+    var ContextResourceString =  require("loctool/lib/ContextResourceString.js");
+    var ResourcePlural =  require("loctool/lib/ResourcePlural.js");
     var TranslationSet =  require("loctool/lib/TranslationSet.js");
 }
 
@@ -501,7 +502,7 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
@@ -533,7 +534,7 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test", "xml"));
         test.ok(r);
 
         test.ok(!r.getSource());
@@ -567,7 +568,7 @@ module.exports.metaxmlfile = {
 
         test.equal(set.size(), 1);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test", "xml"));
         test.ok(r);
 
         test.ok(!r.getSource());
@@ -599,7 +600,7 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test", "xml"));
         test.ok(r);
         test.equal(r.getSource(), "    Enter Your Password \r \n  ");
         test.equal(r.getKey(), "Test");
@@ -660,7 +661,7 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
@@ -692,7 +693,7 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
@@ -724,7 +725,7 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
@@ -756,7 +757,7 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
@@ -792,13 +793,13 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "screen_flows_prebuilt_crt", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "screen_flows_prebuilt_crt", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Screen Flows");
         test.equal(r.getKey(), "screen_flows_prebuilt_crt");
 
-        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test1", "xml"));
+        r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test1", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Flow Interview Log Entries");
@@ -839,19 +840,19 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "screen_flows_prebuilt_crt", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "screen_flows_prebuilt_crt", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Screen Flows");
         test.equal(r.getKey(), "screen_flows_prebuilt_crt");
 
-        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test1", "xml"));
+        r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test1", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Flow Interview Log Entries");
         test.equal(r.getKey(), "Test1");
 
-        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test2", "xml"));
+        r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test2", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Flow Interview Logs");
@@ -925,14 +926,14 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "screen_flows_prebuilt_crt", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "screen_flows_prebuilt_crt", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Screen Flows");
         test.equal(r.getKey(), "screen_flows_prebuilt_crt");
         test.equal(r.getComment(), "Screen Flows Description");
 
-        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test1", "xml"));
+        r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test1", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Flow Interview Log Entries");
@@ -968,7 +969,7 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
@@ -1006,13 +1007,13 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
         test.ok(set);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test1", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test1", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
         test.equal(r.getKey(), "Test1");
 
-        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test2", "xml"));
+        r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test2", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Password");
@@ -1054,11 +1055,11 @@ module.exports.metaxmlfile = {
 
         test.equal(set.size(), 1);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Screen Flows", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "foo", "xml"));
         test.ok(r);
 
         test.equal(r.getSource(), "Screen Flows");
-        test.equal(r.getKey(), "Screen Flows");
+        test.equal(r.getKey(), "foo");
         test.equal(r.getComment(), "Screen Flows Description");
         test.equal(r.getSourceLocale(), "en-US");
         test.equal(r.getType(), "string");
@@ -1085,17 +1086,17 @@ module.exports.metaxmlfile = {
 
         test.equal(set.size(), 13);
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "String_only_in_translations_meta_xml", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "String_only_in_translations_meta_xml", "xml"));
         test.ok(r);
         test.equal(r.getSource(), "Translations Only String");
         test.equal(r.getKey(), "String_only_in_translations_meta_xml");
 
-        r = set.get(ResourceString.hashKey("forceapp", "en-US", "Retry_Count__c", "xml"));
+        r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Retry_Count__c", "xml"));
         test.ok(r);
         test.ok(!r.getSource());
         test.equal(r.getKey(), "Retry_Count__c");
 
-        var r = set.get(ResourceString.hashKey("forceapp", "en-US", "MyApp_Files2", "xml"));
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "MyApp_Files2", "xml"));
         test.ok(r);
         test.ok(!r.getSource());
         test.equal(r.getKey(), "MyApp_Files2");
@@ -1138,6 +1139,271 @@ module.exports.metaxmlfile = {
         var set = mxf.getTranslationSet();
 
         test.equal(set.size(), 0);
+
+        test.done();
+    },
+
+    testMetaXmlFileExtractLabelsFile: function(test) {
+        test.expect(8);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/all/labels/MyLabels.labels-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 2);
+
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Show_Sender_in_Recipient_List", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "Show Sender in Recipient List");
+        test.equal(r.getKey(), "Show_Sender_in_Recipient_List");
+
+        r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "Test_of_emergency_warning_system", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "Test of the emergency warning system.");
+        test.equal(r.getKey(), "Test_of_emergency_warning_system");
+
+        test.done();
+    },
+
+    testMetaXmlFileExtractObjectFile: function(test) {
+        test.expect(10);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/main/default/objects/Foo__c/Foo__c.object-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 2);
+
+        var r = set.get(ResourcePlural.hashKey("forceapp", undefined, "en-US", "Foo__c"));
+        test.ok(r);
+        var strings = r.getSourcePlurals();
+        test.ok(strings);
+        test.equal(strings.one, "Lead Convert Queue");
+        test.equal(strings.other, "Lead Convert Queue Entries");
+
+        test.equal(r.getKey(), "Foo__c");
+
+        r = set.get(ContextResourceString.hashKey("forceapp", "CustomObject/nameField/label/_text", "en-US", "Foo__c", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "Lead Convert Queue Name");
+        test.equal(r.getKey(), "Foo__c");
+
+        test.done();
+    },
+
+    testMetaXmlFileExtractApplicationFile: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/main/default/application/MyApp.app-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 1);
+
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "MyApp", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "My Application");
+        test.equal(r.getKey(), "MyApp");
+
+        test.done();
+    },
+
+
+    testMetaXmlFileExtractMetadataFile: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/main/default/customMetadata/MyApp_Setting.Default_Configuration.md-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 1);
+
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "MyApp_Setting", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "Default Configuration");
+        test.equal(r.getKey(), "MyApp_Setting");
+
+        test.done();
+    },
+
+    testMetaXmlFileExtractPermissionsFile: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/main/default/customPermissions/MyApp_Admin.customPermissions-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 1);
+
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "MyApp_Admin", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "MyApp Admin Settings");
+        test.equal(r.getKey(), "MyApp_Admin");
+
+        test.done();
+    },
+
+    testMetaXmlFileExtractFieldFile: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/main/default/objects/Foo__c/fields/AccessToken_Expr__c.field-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 1);
+
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "AccessToken_Expr__c", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "Access token expired");
+        test.equal(r.getKey(), "AccessToken_Expr__c");
+
+        test.done();
+    },
+
+    testMetaXmlFileExtractListViewFile: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/main/default/objects/Foo__c/listviews/ListView.listView-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 1);
+
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "All", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "All items");
+        test.equal(r.getKey(), "All");
+
+        test.done();
+    },
+
+    testMetaXmlFileExtractPermissionsFile: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/main/default/permissionsets/Standard.permissionset-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 1);
+
+        var r = set.get(ContextResourceString.hashKey("forceapp", "Foo__c", "en-US", "Standard", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "MyApp Standard");
+        test.equal(r.getKey(), "Standard");
+
+        test.done();
+    },
+
+    testMetaXmlFileExtractQuickActionsFile: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/main/default/quickActions/SendEmail.quickAction-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 1);
+
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "SendEmail", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "Send Email");
+        test.equal(r.getKey(), "SendEmail");
+
+        test.done();
+    },
+
+    testMetaXmlFileExtractTabsFile: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./force-app/main/default/tabs/MyApp_Files2.tab-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        var set = mxf.getTranslationSet();
+
+        test.equal(set.size(), 1);
+
+        var r = set.get(ContextResourceString.hashKey("forceapp", undefined, "en-US", "MyApp_Files2", "xml"));
+        test.ok(r);
+        test.equal(r.getSource(), "My Application Files");
+        test.equal(r.getKey(), "MyApp_Files2");
 
         test.done();
     },
@@ -1272,7 +1538,7 @@ module.exports.metaxmlfile = {
         test.ok(set);
         test.equal(set.size(), 0);
 
-        mxf.addResource(new ResourceString({
+        mxf.addResource(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Password',
@@ -1301,7 +1567,7 @@ module.exports.metaxmlfile = {
         test.ok(set);
         test.equal(set.size(), 0);
 
-        mxf.addResource(new ResourceString({
+        mxf.addResource(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Password',
@@ -1310,7 +1576,7 @@ module.exports.metaxmlfile = {
             target: "Passwort",
             targetLocale: "de-DE"
         }));
-        mxf.addResource(new ResourceString({
+        mxf.addResource(new ContextResourceString({
             project: "forceapp",
             key: 'user',
             source: 'Username',
@@ -1401,7 +1667,7 @@ module.exports.metaxmlfile = {
 
         test.equal(set.size(), 2);
 
-        mxf.addResource(new ResourceString({
+        mxf.addResource(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             sourceLocale: "en-US",
@@ -1410,7 +1676,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             pathName: "force-app/main/apps/main.application-meta.xml"
         }));
-        mxf.addResource(new ResourceString({
+        mxf.addResource(new ContextResourceString({
             project: "forceapp",
             key: 'user',
             sourceLocale: "en-US",
@@ -1470,7 +1736,7 @@ module.exports.metaxmlfile = {
         test.equal(set.size(), 2);
 
         var translations = new TranslationSet();
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Password',
@@ -1481,7 +1747,7 @@ module.exports.metaxmlfile = {
             targetLocale: "de-DE",
             pathName: "force-app/main/default/translations/en_US.translation-meta.xml"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'user',
             source: 'Username',
@@ -1549,7 +1815,7 @@ module.exports.metaxmlfile = {
         test.equal(set.size(), 2);
 
         var translations = new TranslationSet();
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Password',
@@ -1617,7 +1883,7 @@ module.exports.metaxmlfile = {
         test.equal(set.size(), 2);
 
         var translations = new TranslationSet();
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Password',
@@ -1667,7 +1933,7 @@ module.exports.metaxmlfile = {
         );
 
         var translations = new TranslationSet();
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             source: '',
@@ -1723,7 +1989,7 @@ module.exports.metaxmlfile = {
         );
 
         // fill in the source strings
-        mxf.addResource(new ResourceString({
+        mxf.addResource(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             sourceLocale: "en-US",
@@ -1732,7 +1998,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             pathName: "force-app/main/apps/main.application-meta.xml"
         }));
-        mxf.addResource(new ResourceString({
+        mxf.addResource(new ContextResourceString({
             project: "forceapp",
             key: 'user',
             sourceLocale: "en-US",
@@ -1743,7 +2009,7 @@ module.exports.metaxmlfile = {
         }));
 
         var translations = new TranslationSet();
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             source: '',
@@ -1771,184 +2037,6 @@ module.exports.metaxmlfile = {
     },
 
 /*
-    testMetaXmlFileLocalizeSimple: function(test) {
-        test.expect(2);
-
-        var base = path.dirname(module.id);
-
-        var mxf = new MetaXmlFile({
-            project: p,
-            pathName: "./force-app/main/default/translations/en_US.translation-meta.xml",
-            type: mxft
-        });
-        test.ok(mxf);
-
-        mxf.parse(
-            '<?xml version="1.0" encoding="UTF-8"?>\n' +
-            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
-            '    <customApplications>\n' +
-            '        <label>Password</label>\n' +
-            '        <name>Test</name>\n' +
-            '    </customApplications>\n' +
-            '</Translations>\n'
-        );
-
-        var translations = new TranslationSet();
-        translations.add(new ResourceString({
-            project: "forceapp",
-            key: 'Test',
-            source: 'Password',
-            target: 'Passwort',
-            targetLocale: "de-DE",
-            datatype: "xml",
-            context: "customApplications"
-        }));
-
-        content = mxf.localizeText(translations, "de-DE");
-
-        var expected =
-            '<?xml version="1.0" encoding="UTF-8"?>\n' +
-            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
-            '    <customApplications>\n' +
-            '        <label>Passwort</label>\n' +
-            '        <name>Test</name>\n' +
-            '    </customApplications>\n' +
-            '</Translations>\n';
-
-        diff(content, expected);
-        test.equal(content, expected);
-
-        test.done();
-    },
-
-    testMetaXmlFileLocalizeTextEscapeXmlSyntax: function(test) {
-        test.expect(2);
-
-        var base = path.dirname(module.id);
-
-        var mxf = new MetaXmlFile({
-            project: p,
-            pathName: "./force-app/main/default/translations/en_US.translation-meta.xml",
-            type: mxft
-        });
-        test.ok(mxf);
-
-        mxf.parse(
-            '<?xml version="1.0" encoding="UTF-8"?>\n' +
-            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
-            '    <customApplications>\n' +
-            '        <label>Password &lt;name> &uuml;</label>\n' +
-            '        <name>Test</name>\n' +
-            '    </customApplications>\n' +
-            '</Translations>\n'
-        );
-
-        var translations = new TranslationSet();
-        translations.add(new ResourceString({
-            project: "forceapp",
-            key: 'Test',
-            source: 'Password <name> &uuml;',
-            target: 'Passwort <name> &uuml;',
-            targetLocale: "de-DE",
-            datatype: "xml",
-            context: "customApplications"
-        }));
-
-        content = mxf.localizeText(translations, "de-DE");
-
-        var expected =
-            '<?xml version="1.0" encoding="UTF-8"?>\n' +
-            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
-            '    <customApplications>\n' +
-            '        <label>Passwort &lt;name&gt; &amp;uuml;</label>\n' +
-            '        <name>Test</name>\n' +
-            '    </customApplications>\n' +
-            '</Translations>\n';
-
-        diff(content, expected);
-        test.equal(content, expected);
-
-        test.done();
-    },
-
-    testMetaXmlFileLocalizeReportTypes: function(test) {
-        test.expect(2);
-
-        var base = path.dirname(module.id);
-
-        var mxf = new MetaXmlFile({
-            project: p,
-            pathName: "./force-app/main/default/translations/en_US.translation-meta.xml",
-            type: mxft
-        });
-        test.ok(mxf);
-
-        mxf.parse(
-            '<?xml version="1.0" encoding="UTF-8"?>\n' +
-            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
-            '    <reportTypes>\n' +
-            '        <description>Screen Flows Description</description>\n' +
-            '        <label>Coule d\'écran</label>\n' +
-            '        <name>screen_flows_prebuilt_crt</name>\n' +
-            '        <sections>\n' +
-            '            <label>Entrées de journal pour coule de entretien</label>\n' +
-            '            <name>Flow Interview Log Entries</name>\n' +
-            '        </sections>\n' +
-            '    </reportTypes>\n' +
-            '</Translations>\n'
-        );
-
-        var translations = new TranslationSet();
-        translations.add(new ResourceString({
-            project: "forceapp",
-            key: 'screen_flows_prebuilt_crt',
-            source: 'Screen Flows',
-            target: "Coule d'écran",
-            targetLocale: "fr-FR",
-            datatype: "xml",
-            context: "reportTypes"
-        }));
-        translations.add(new ResourceString({
-            project: "forceapp",
-            key: 'screen_flows_prebuilt_crt.description',
-            source: 'Screen Flows Description',
-            target: "Description de coule d'écran",
-            targetLocale: "fr-FR",
-            datatype: "xml",
-            context: "reportTypes"
-        }));
-        translations.add(new ResourceString({
-            project: "forceapp",
-            key: 'screen_flows_prebuilt_crt.Flow Interview Log Entries',
-            source: 'Flow Interview Log Entries',
-            target: "Entrées de journal pour coule de entretien",
-            targetLocale: "fr-FR",
-            datatype: "xml",
-            context: "reportTypes.sections"
-        }));
-
-        content = mxf.localizeText(translations, "fr-FR");
-
-        var expected =
-            '<?xml version="1.0" encoding="UTF-8"?>\n' +
-            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
-            '    <reportTypes>\n' +
-            '        <description>Description de coule d\'écran</description>\n' +
-            '        <label>Coule d\'écran</label>\n' +
-            '        <name>screen_flows_prebuilt_crt</name>\n' +
-            '        <sections>\n' +
-            '            <label>Entrées de journal pour coule de entretien</label>\n' +
-            '            <name>Flow Interview Log Entries</name>\n' +
-            '        </sections>\n' +
-            '    </reportTypes>\n' +
-            '</Translations>\n';
-
-        diff(content, expected);
-        test.equal(content, expected);
-
-        test.done();
-    },
-
     testMetaXmlFileLocalize: function(test) {
         test.expect(5);
 
@@ -1965,7 +2053,7 @@ module.exports.metaxmlfile = {
         mxf.extract();
 
         var translations = new TranslationSet();
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Test',
@@ -1974,7 +2062,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "customApplications"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Force_com',
             source: 'Force.com',
@@ -1983,7 +2071,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "customApplications"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Account',
             source: 'Text Account',
@@ -1992,7 +2080,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "customLabels"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Files2',
             source: 'Files online',
@@ -2001,7 +2089,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "customTabs"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'LogACall',
             source: 'LogACall',
@@ -2010,7 +2098,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "quickActions"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt',
             source: 'Screen Flows',
@@ -2019,7 +2107,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.description',
             source: 'Screen Flows Description',
@@ -2028,7 +2116,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.Flow Interview Log Entries',
             source: 'Flow Interview Log Entries',
@@ -2037,7 +2125,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "reportTypes.sections"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.Flow Interview Logs',
             source: 'Flow Interview Logs',
@@ -2047,7 +2135,7 @@ module.exports.metaxmlfile = {
             context: "reportTypes.sections"
         }));
 
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Test',
             source: 'Test',
@@ -2056,7 +2144,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "customApplications"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Force_com',
             source: 'Force.com',
@@ -2065,7 +2153,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "customApplications"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Account',
             source: 'Text Account',
@@ -2074,7 +2162,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "customLabels"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'Files2',
             source: 'Files online',
@@ -2083,7 +2171,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "customTabs"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'LogACall',
             source: 'LogACall',
@@ -2092,7 +2180,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "quickActions"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt',
             source: 'Screen Flows',
@@ -2101,7 +2189,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.description',
             source: 'Screen Flows Description',
@@ -2110,7 +2198,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "reportTypes"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.Flow Interview Log Entries',
             source: 'Flow Interview Log Entries',
@@ -2119,7 +2207,7 @@ module.exports.metaxmlfile = {
             datatype: "xml",
             context: "reportTypes.sections"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'screen_flows_prebuilt_crt.Flow Interview Logs',
             source: 'Flow Interview Logs',
@@ -2222,7 +2310,393 @@ module.exports.metaxmlfile = {
 
         test.done();
     },
+*/
 
+    testMetaXmlFileLocalizeWithNoSourceStrings: function(test) {
+        test.expect(5);
+
+        var base = path.dirname(module.id);
+
+        var mxf = mxft.newFile("./force-app/main/default/translations/en_US.translation-meta.xml");
+        test.ok(mxf);
+
+        // should read the file
+        mxf.extract();
+
+        // now read the other xml files to find the source strings
+        [
+            "./force-app/all/labels/MyLabels.labels-meta.xml",
+            "./force-app/main/default/application/MyApp.app-meta.xml",
+            "./force-app/main/default/customMetadata/MyApp_Setting.Default_Configuration.md-meta.xml",
+            "./force-app/main/default/customPermissions/MyApp_Admin.customPermissions-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/AccessToken_Expr__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/Allocation_status__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/Collaboration__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/fields/Retry_Count__c.field-meta.xml",
+            "./force-app/main/default/objects/Foo__c/listviews/ListView.listView-meta.xml",
+            "./force-app/main/default/objects/Foo__c/Foo__c.object-meta.xml",
+            "./force-app/main/default/quickActions/SendEmail.quickAction-meta.xml",
+            "./force-app/main/default/tabs/MyApp_Files2.tab-meta.xml"
+        ].forEach(function(pathName) {
+            var sourceXml = mxft.newFile(pathName);
+            sourceXml.extract();
+            mxf.addSet(sourceXml.getTranslationSet());
+        });
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp',
+            source: '',
+            target: 'MonApp',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'AcessToken_Expr__c',
+            source: '',
+            target: 'Jetons d\'accès',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Allocation_status__c',
+            source: '',
+            target: 'Statut d\'attribution',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Collaboration__c',
+            source: '',
+            target: 'Collaborations',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Retry_Count__c',
+            source: '',
+            target: 'Nombre de tentatives',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Show_Sender_in_Recipient_List',
+            source: '',
+            target: 'Afficher l\'expéditeur dans la liste des destinataires',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Test_of_emergency_warning_system',
+            source: '',
+            target: 'Test du système d\'accès d\'urgence',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'String_only_in_translations_meta_xml',
+            source: 'Translations Only String',
+            target: 'Chaîne qui se trouve uniquement dans les traductions',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp_Files2',
+            source: '',
+            target: 'Onglet Fichiers',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'LogACall',
+            source: '',
+            target: 'EnregistrerUnAppel',
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt',
+            source: '',
+            target: "Coule d'écran",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt.description',
+            source: '',
+            target: "Description de coule d'écran",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Log Entries',
+            source: '',
+            target: "Entrées de journal pour coule de entretien",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Logs',
+            source: '',
+            target: "Journals pour coule de entretien",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp',
+            source: '',
+            target: 'MeineApp',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'AcessToken_Expr__c',
+            source: '',
+            target: 'Zugriffstoken',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Allocation_status__c',
+            source: '',
+            target: 'Zuordnungsstatus',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Collaboration__c',
+            source: '',
+            target: 'Zusammenarbeit',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Retry_Count__c',
+            source: '',
+            target: 'Anzahl der Wiederholungen',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Show_Sender_in_Recipient_List',
+            source: '',
+            target: 'Den Absender in der Empfängerliste anzeigen',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Test_of_emergency_warning_system',
+            source: '',
+            target: 'Test des Notzugangssystems',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'String_only_in_translations_meta_xml',
+            source: 'Translations Only String',
+            target: 'String, der nur in den Übersetzungen vorkommt',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'MyApp_Files2',
+            source: '',
+            target: 'Registerkarte Dateien',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'LogACall',
+            source: '',
+            target: 'Anruf protokollieren',
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'screen_flows_prebuilt_crt',
+            source: 'Screen Flows',
+            target: "Bildschirmsflussen",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Log Entries',
+            source: 'Flow Interview Log Entries',
+            target: "Protokolleinträge von Flussinterviews",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "forceapp",
+            key: 'Flow Interview Logs',
+            source: 'Flow Interview Logs',
+            target: "Protokollen von Flussinterviews",
+            targetLocale: "de-DE",
+            datatype: "xml"
+        }));
+
+        // now cause the localization by asking the filetype object to write
+        // out all of them
+        mxft.write(translations, ["fr-FR", "de-DE"]);
+
+        test.ok(fs.existsSync(path.join(base, "testfiles/force-app/main/default/translations/fr.translation-meta.xml")));
+        test.ok(fs.existsSync(path.join(base, "testfiles/force-app/main/default/translations/de.translation-meta.xml")));
+
+        var content = fs.readFileSync(path.join(base, "testfiles/force-app/main/default/translations/fr.translation-meta.xml"), "UTF-8");
+
+        var expected =
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <customApplications>\n' +
+            '        <label>MonApp</label>\n' +
+            '        <name>MyApp</name>\n' +
+            '    </customApplications>\n' +
+            '    <customField>\n' +
+            '        <label>Jetons d\'accès</label>\n' +
+            '        <name>AcessToken_Expr__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Statut d\'attribution</label>\n' +
+            '        <name>Allocation_status__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Collaborations</label>\n' +
+            '        <name>Collaboration__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Nombre de tentatives</label>\n' +
+            '        <name>Retry_Count__c</name>\n' +
+            '    </customField>\n' +
+            '    <customLabels>\n' +
+            '        <label>Afficher l\'expéditeur dans la liste des destinataires</label>\n' +
+            '        <name>Show_Sender_in_Recipient_List</name>\n' +
+            '    </customLabels>\n' +
+            '    <customLabels>\n' +
+            '        <label>Test du système d\'accès d\'urgence</label>\n' +
+            '        <name>Test_of_emergency_warning_system</name>\n' +
+            '    </customLabels>\n' +
+            '    <customLabels>\n' +
+            '        <label>Chaîne qui se trouve uniquement dans les traductions</label>\n' +
+            '        <name>String_only_in_translations_meta_xml</name>\n' +
+            '    </customLabels>\n' +
+            '    <customTabs>\n' +
+            '        <label>Onglet Fichiers</label>\n' +
+            '        <name>MyApp_Files2</name>\n' +
+            '    </customTabs>\n' +
+            '    <quickActions>\n' +
+            '        <label>EnregistrerUnAppel</label>\n' +
+            '        <name>LogACall</name>\n' +
+            '    </quickActions>\n' +
+            '    <reportTypes>\n' +
+            '        <label>Coule d\'écran</label>\n' +
+            '        <name>screen_flows_prebuilt_crt</name>\n' +
+            '        <sections>\n' +
+            '            <label>Entrées de journal pour coule de entretien</label>\n' +
+            '            <name>Flow Interview Log Entries</name>\n' +
+            '        </sections>\n' +
+            '        <sections>\n' +
+            '            <label>Journals pour coule de entretien</label>\n' +
+            '            <name>Flow Interview Logs</name>\n' +
+            '        </sections>\n' +
+            '    </reportTypes>\n' +
+            '</Translations>\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        content = fs.readFileSync(path.join(base, "testfiles/force-app/main/default/translations/de.translation-meta.xml"), "UTF-8");
+
+        var expected =
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <customApplications>\n' +
+            '        <label>MeineApp</label>\n' +
+            '        <name>MyApp</name>\n' +
+            '    </customApplications>\n' +
+            '    <customField>\n' +
+            '        <label>Zugriffstoken</label>\n' +
+            '        <name>AcessToken_Expr__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Zuordnungsstatus</label>\n' +
+            '        <name>Allocation_status__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Zusammenarbeit</label>\n' +
+            '        <name>Collaboration__c</name>\n' +
+            '    </customField>\n' +
+            '    <customField>\n' +
+            '        <label>Anzahl der Wiederholungen</label>\n' +
+            '        <name>Retry_Count__c</name>\n' +
+            '    </customField>\n' +
+            '    <customLabels>\n' +
+            '        <label>Den Absender in der Empfängerliste anzeigen</label>\n' +
+            '        <name>Show_Sender_in_Recipient_List</name>\n' +
+            '    </customLabels>\n' +
+            '    <customLabels>\n' +
+            '        <label>Test des Notzugangssystems</label>\n' +
+            '        <name>Test_of_emergency_warning_system</name>\n' +
+            '    </customLabels>\n' +
+            '    <customLabels>\n' +
+            '        <label>String, der nur in den Übersetzungen vorkommt</label>\n' +
+            '        <name>String_only_in_translations_meta_xml</name>\n' +
+            '    </customLabels>\n' +
+            '    <customTabs>\n' +
+            '        <label>Registerkarte Dateien</label>\n' +
+            '        <name>MyApp_Files2</name>\n' +
+            '    </customTabs>\n' +
+            '    <quickActions>\n' +
+            '        <label>Anruf protokollieren</label>\n' +
+            '        <name>LogACall</name>\n' +
+            '    </quickActions>\n' +
+            '    <reportTypes>\n' +
+            '        <label>Bildschirmsflussen</label>\n' +
+            '        <name>screen_flows_prebuilt_crt</name>\n' +
+            '        <sections>\n' +
+            '            <label>Protokolleinträge von Flussinterviews</label>\n' +
+            '            <name>Flow Interview Log Entries</name>\n' +
+            '        </sections>\n' +
+            '        <sections>\n' +
+            '            <label>Protokollen von Flussinterviews</label>\n' +
+            '            <name>Flow Interview Logs</name>\n' +
+            '        </sections>\n' +
+            '    </reportTypes>\n' +
+            '</Translations>\n';
+
+        diff(content, expected);
+        test.equal(content, expected);
+
+        test.done();
+    },
+
+/*
     testMetaXmlFileLocalizeNoStrings: function(test) {
         test.expect(5);
 
@@ -2257,7 +2731,7 @@ module.exports.metaxmlfile = {
         );
 
         var translations = new TranslationSet();
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'r308704783',
             source: 'Get insurance quotes for free!',
@@ -2265,7 +2739,7 @@ module.exports.metaxmlfile = {
             targetLocale: "fr-FR",
             datatype: "xml"
         }));
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'r308704783',
             source: 'Get insurance quotes for free!',
@@ -2307,7 +2781,7 @@ module.exports.metaxmlfile = {
         );
 
         var translations = new TranslationSet();
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'foo',
             source: 'bar',
@@ -2380,7 +2854,7 @@ module.exports.metaxmlfile = {
         );
 
         var translations = new TranslationSet();
-        translations.add(new ResourceString({
+        translations.add(new ContextResourceString({
             project: "forceapp",
             key: 'foo',
             source: 'bar',

--- a/test/testMetaXmlFile.js
+++ b/test/testMetaXmlFile.js
@@ -78,7 +78,10 @@ var p2 = new CustomProject({
 }, "./test/testfiles", {
     locales:["en-GB"],
     identify: true,
-    targetDir: "testfiles"
+    targetDir: "testfiles",
+    metaxml: {
+        resourceFile: "force-app/main/default/translations/[localeUnder].translation-meta.xml"
+    }
 });
 
 var t = new MetaXmlFileType(p2);
@@ -573,7 +576,7 @@ module.exports.metaxmlfile = {
         test.done();
     },
 
-    testMetaXmlFileParseSimpleIgnoreWhitespace: function(test) {
+    testMetaXmlFileParseSimplePreserveWhitespace: function(test) {
         test.expect(5);
 
         var mxf = new MetaXmlFile({
@@ -598,7 +601,7 @@ module.exports.metaxmlfile = {
 
         var r = set.get(ResourceString.hashKey("forceapp", "en-US", "Test", "xml"));
         test.ok(r);
-        test.equal(r.getSource(), "Enter Your Password");
+        test.equal(r.getSource(), "    Enter Your Password \r \n  ");
         test.equal(r.getKey(), "Test");
 
         test.done();
@@ -1149,7 +1152,8 @@ module.exports.metaxmlfile = {
         });
         test.ok(mxf);
 
-        test.equal(mxf.getLocalizedPath("de-DE"), "de.translation-meta.xml");
+        // resource file template is in the settings.metaxml.resourceFile property
+        test.equal(mxf.getLocalizedPath("de-DE"), "force-app/main/default/translations/de.translation-meta.xml");
         test.done();
     },
 
@@ -1163,7 +1167,7 @@ module.exports.metaxmlfile = {
         });
         test.ok(mxf);
 
-        test.equal(mxf.getLocalizedPath("de-DE"), "src/translations/de.translation-meta.xml");
+        test.equal(mxf.getLocalizedPath("de-DE"), "force-app/main/default/translations/de.translation-meta.xml");
         test.done();
     },
 
@@ -1177,7 +1181,7 @@ module.exports.metaxmlfile = {
         });
         test.ok(mxf);
 
-        test.equal(mxf.getLocalizedPath("de-AT"), "de_AT.translation-meta.xml");
+        test.equal(mxf.getLocalizedPath("de-AT"), "force-app/main/default/translations/de_AT.translation-meta.xml");
         test.done();
     },
 
@@ -1192,7 +1196,7 @@ module.exports.metaxmlfile = {
         });
         test.ok(mxf);
 
-        test.equal(mxf.getLocalizedPath("nb-NO"), "no.translation-meta.xml");
+        test.equal(mxf.getLocalizedPath("nb-NO"), "force-app/main/default/translations/no.translation-meta.xml");
         test.done();
     },
 
@@ -1206,21 +1210,7 @@ module.exports.metaxmlfile = {
         });
         test.ok(mxf);
 
-        test.equal(mxf.getLocalizedPath("zh-Hans-CN"), "zh_CN.translation-meta.xml");
-        test.done();
-    },
-
-    testMetaXmlFileGetLocalizedPathSpecialMappingOldHebrew: function(test) {
-        test.expect(2);
-
-        var mxf = new MetaXmlFile({
-            project: p,
-            pathName: "./en_US.translation-meta.xml",
-            type: mxft
-        });
-        test.ok(mxf);
-
-        test.equal(mxf.getLocalizedPath("he-IL"), "iw.translation-meta.xml");
+        test.equal(mxf.getLocalizedPath("zh-Hans-CN"), "force-app/main/default/translations/zh_CN.translation-meta.xml");
         test.done();
     },
 
@@ -1234,7 +1224,7 @@ module.exports.metaxmlfile = {
         });
         test.ok(mxf);
 
-        test.equal(mxf.getLocalizedPath("es-419"), "es_MX.translation-meta.xml");
+        test.equal(mxf.getLocalizedPath("es-419"), "force-app/main/default/translations/es_MX.translation-meta.xml");
         test.done();
     },
 
@@ -1248,11 +1238,280 @@ module.exports.metaxmlfile = {
         });
         test.ok(mxf);
 
-        test.equal(mxf.getLocalizedPath("pt_PT"), "pt_PT.translation-meta.xml");
-        test.equal(mxf.getLocalizedPath("pt_BR"), "pt_BR.translation-meta.xml");
+        test.equal(mxf.getLocalizedPath("pt-PT"), "force-app/main/default/translations/pt_PT.translation-meta.xml");
+        test.equal(mxf.getLocalizedPath("pt-BR"), "force-app/main/default/translations/pt_BR.translation-meta.xml");
         test.done();
     },
 
+    testMetaXmlFileGetLocalizedPath: function(test) {
+        test.expect(3);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            pathName: "./en_US.translation-meta.xml",
+            type: mxft
+        });
+        test.ok(mxf);
+
+        test.equal(mxf.getLocalizedPath("pt-PT"), "force-app/main/default/translations/pt_PT.translation-meta.xml");
+        test.equal(mxf.getLocalizedPath("pt-BR"), "force-app/main/default/translations/pt_BR.translation-meta.xml");
+        test.done();
+    },
+
+    testMetaXmlFileAddResource: function(test) {
+        test.expect(4);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft,
+            locale: "de-DE"
+        });
+        test.ok(mxf);
+
+        var set = mxf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 0);
+
+        mxf.addResource(new ResourceString({
+            project: "forceapp",
+            key: 'Test',
+            source: 'Password',
+            comment: "comment",
+            datatype: "xml",
+            target: "Passwort",
+            targetLocale: "de-DE"
+        }));
+
+        test.equal(set.size(), 1);
+
+        test.done();
+    },
+
+    testMetaXmlFileAddMultipleResources: function(test) {
+        test.expect(4);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft,
+            locale: "de-DE"
+        });
+        test.ok(mxf);
+
+        var set = mxf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 0);
+
+        mxf.addResource(new ResourceString({
+            project: "forceapp",
+            key: 'Test',
+            source: 'Password',
+            comment: "comment",
+            datatype: "xml",
+            target: "Passwort",
+            targetLocale: "de-DE"
+        }));
+        mxf.addResource(new ResourceString({
+            project: "forceapp",
+            key: 'user',
+            source: 'Username',
+            comment: "comment",
+            datatype: "xml",
+            target: "Benutzername",
+            targetLocale: "de-DE"
+        }));
+
+        test.equal(set.size(), 2);
+
+        test.done();
+    },
+
+    testMetaXmlFileLocalizeTextSimpleNoSource: function(test) {
+        test.expect(5);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft,
+            locale: "de-DE"
+        });
+        test.ok(mxf);
+
+        var set = mxf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 0);
+
+        mxf.parse(
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <customApplications>\n' +
+            '        <label><!-- Password --></label>\n' +
+            '        <name>Test</name>\n' +
+            '    </customApplications>\n' +
+            '    <customApplications>\n' +
+            '        <label><!-- username --></label>\n' +
+            '        <name>user</name>\n' +
+            '    </customApplications>\n' +
+            '</Translations>\n'
+        );
+
+        test.equal(set.size(), 2);
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "forceapp",
+            key: 'Test',
+            source: 'Password',
+            sourceLocale: "en-US",
+            comment: "comment",
+            datatype: "xml",
+            target: "Passwort",
+            targetLocale: "de-DE",
+            pathName: "force-app/main/default/translations/en_US.translation-meta.xml"
+        }));
+        translations.add(new ResourceString({
+            project: "forceapp",
+            key: 'user',
+            source: 'Username',
+            sourceLocale: "en-US",
+            comment: "comment",
+            datatype: "xml",
+            target: "Benutzername",
+            targetLocale: "de-DE",
+            pathName: "force-app/main/default/translations/en_US.translation-meta.xml"
+        }));
+
+        // should translate anyways, despite having no source strings
+        var actual = mxf.localizeText(translations, "de-DE");
+        var expected =
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <customApplications>\n' +
+            '        <label>Passwort</label>\n' +
+            '        <name>Test</name>\n' +
+            '    </customApplications>\n' +
+            '    <customApplications>\n' +
+            '        <label>Benutzername</label>\n' +
+            '        <name>user</name>\n' +
+            '    </customApplications>\n' +
+            '</Translations>\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testMetaXmlFileGetTextSimpleNoSourceInExtracted: function(test) {
+        test.expect(14);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft,
+            locale: "de-DE"
+        });
+        test.ok(mxf);
+
+        var set = mxf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 0);
+
+        mxf.parse(
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <customApplications>\n' +
+            '        <label><!-- Password --></label>\n' +
+            '        <name>Test</name>\n' +
+            '    </customApplications>\n' +
+            '    <customApplications>\n' +
+            '        <label><!-- username --></label>\n' +
+            '        <name>user</name>\n' +
+            '    </customApplications>\n' +
+            '</Translations>\n'
+        );
+
+        test.equal(set.size(), 2);
+
+        var resources = set.getAll();
+        test.ok(resources);
+        test.equal(resources.length, 2);
+
+        test.equal(resources[0].getKey(), "Test");
+        test.ok(!resources[0].getSource());
+        test.equal(resources[0].getSourceLocale(), "en-US");
+        test.equal(resources[0].getState(), "new");
+
+        test.equal(resources[1].reskey, "user");
+        test.ok(!resources[1].getSource());
+        test.equal(resources[1].sourceLocale, "en-US");
+        test.equal(resources[1].state, "new");
+
+        test.done();
+    },
+
+    testMetaXmlFileGetTextSimpleAddSourceInExtractedFromOtherResources: function(test) {
+        test.expect(14);
+
+        var mxf = new MetaXmlFile({
+            project: p,
+            type: mxft
+        });
+        test.ok(mxf);
+
+        var set = mxf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 0);
+
+        mxf.parse(
+            '<?xml version="1.0" encoding="UTF-8"?>\n' +
+            '<Translations xmlns="http://soap.sforce.com/2006/04/metadata">\n' +
+            '    <customApplications>\n' +
+            '        <label><!-- Password --></label>\n' +
+            '        <name>Test</name>\n' +
+            '    </customApplications>\n' +
+            '    <customApplications>\n' +
+            '        <label><!-- username --></label>\n' +
+            '        <name>user</name>\n' +
+            '    </customApplications>\n' +
+            '</Translations>\n'
+        );
+
+        test.equal(set.size(), 2);
+
+        mxf.addResource(new ResourceString({
+            project: "forceapp",
+            key: 'Test',
+            sourceLocale: "en-US",
+            source: "Password",
+            comment: "comment1",
+            datatype: "xml",
+            pathName: "force-app/main/apps/main.application-meta.xml"
+        }));
+        mxf.addResource(new ResourceString({
+            project: "forceapp",
+            key: 'user',
+            sourceLocale: "en-US",
+            source: "User Name",
+            comment: "comment2",
+            datatype: "xml",
+            pathName: "force-app/main/apps/main2.application-meta.xml"
+        }));
+
+        var resources = set.getAll();
+        test.ok(resources);
+        test.equal(resources.length, 2);
+
+        test.equal(resources[0].getKey(), "Test");
+        test.equal(resources[0].getSource(), "Password");
+        test.equal(resources[0].getSourceLocale(), "en-US");
+        test.equal(resources[0].getState(), "new");
+
+        test.equal(resources[1].reskey, "user");
+        test.equal(resources[1].getSource(), "User Name");
+        test.equal(resources[1].sourceLocale, "en-US");
+        test.equal(resources[1].state, "new");
+
+        test.done();
+    },
+/*
     testMetaXmlFileLocalizeSimple: function(test) {
         test.expect(2);
 
@@ -1889,4 +2148,5 @@ module.exports.metaxmlfile = {
 
         test.done();
     }
+*/
 };

--- a/test/testMetaXmlFileType.js
+++ b/test/testMetaXmlFileType.js
@@ -92,7 +92,7 @@ module.exports.metaxmlfiletype = {
         var mxft = new MetaXmlFileType(p);
         test.ok(mxft);
 
-        test.ok(!mxft.handles("translations/en_US.field-meta.xml"));
+        test.ok(!mxft.handles("translations/en_US.translate-meta.xml"));
 
         test.done();
     },
@@ -151,4 +151,103 @@ module.exports.metaxmlfiletype = {
 
         test.done();
     },
+
+    testMetaXmlFileTypeHandlesCustomApplicationFile: function(test) {
+        test.expect(2);
+
+        var mxft = new MetaXmlFileType(p);
+        test.ok(mxft);
+
+        test.ok(mxft.handles("force-app/main/default/app/myapp.app-meta.xml"));
+
+        test.done();
+    },
+
+    testMetaXmlFileTypeHandlesCustomFieldFile: function(test) {
+        test.expect(2);
+
+        var mxft = new MetaXmlFileType(p);
+        test.ok(mxft);
+
+        test.ok(mxft.handles("force-app/main/default/app/Field__c.field-meta.xml"));
+
+        test.done();
+    },
+
+    testMetaXmlFileTypeHandlesLabelsFile: function(test) {
+        test.expect(2);
+
+        var mxft = new MetaXmlFileType(p);
+        test.ok(mxft);
+
+        test.ok(mxft.handles("force-app/main/default/app/Field__c.labels-meta.xml"));
+
+        test.done();
+    },
+
+    testMetaXmlFileTypeHandlesCustomMetadataFile: function(test) {
+        test.expect(2);
+
+        var mxft = new MetaXmlFileType(p);
+        test.ok(mxft);
+
+        test.ok(mxft.handles("force-app/main/default/app/myapp.md-meta.xml"));
+
+        test.done();
+    },
+
+    testMetaXmlFileTypeHandlesCustomObjectFile: function(test) {
+        test.expect(2);
+
+        var mxft = new MetaXmlFileType(p);
+        test.ok(mxft);
+
+        test.ok(mxft.handles("force-app/main/default/app/myapp.object-meta.xml"));
+
+        test.done();
+    },
+
+    testMetaXmlFileTypeHandlesCustomPermissionsFile: function(test) {
+        test.expect(2);
+
+        var mxft = new MetaXmlFileType(p);
+        test.ok(mxft);
+
+        test.ok(mxft.handles("force-app/main/default/app/myapp.customPermission-meta.xml"));
+
+        test.done();
+    },
+
+    testMetaXmlFileTypeHandlesCustomTabFile: function(test) {
+        test.expect(2);
+
+        var mxft = new MetaXmlFileType(p);
+        test.ok(mxft);
+
+        test.ok(mxft.handles("force-app/main/default/app/myapp.tab-meta.xml"));
+
+        test.done();
+    },
+
+    testMetaXmlFileTypeHandlesQuickActionFile: function(test) {
+        test.expect(2);
+
+        var mxft = new MetaXmlFileType(p);
+        test.ok(mxft);
+
+        test.ok(mxft.handles("force-app/main/default/app/myapp.quickAction-meta.xml"));
+
+        test.done();
+    },
+
+    testMetaXmlFileTypeDoesNotHandleOtherFiles: function(test) {
+        test.expect(2);
+
+        var mxft = new MetaXmlFileType(p);
+        test.ok(mxft);
+
+        test.ok(!mxft.handles("force-app/main/default/app/myapp.page-meta.xml"));
+
+        test.done();
+    }
 };

--- a/test/testfiles/force-app/all/labels/MyLabels.labels-meta.xml
+++ b/test/testfiles/force-app/all/labels/MyLabels.labels-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <labels>
+        <fullName>Show_Sender_in_Recipient_List</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Whether or not the sender should be shown in the recipient list of the email.</shortDescription>
+        <value>Show Sender in Recipient List</value>
+        <categories>email</categories>
+    </labels>
+    <labels>
+        <fullName>Test_of_emergency_warning_system</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Had this been a real test, you would have been instructed to calmly leave the building.</shortDescription>
+        <value>Test of the emergency warning system.</value>
+        <categories></categories>
+    </labels>
+</CustomLabels>

--- a/test/testfiles/force-app/main/default/application/MyApp.app-meta.xml
+++ b/test/testfiles/force-app/main/default/application/MyApp.app-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
+    <brand>
+        <headerColor>#0061D5</headerColor>
+        <logo>blue</logo>
+        <logoVersion>1.0</logoVersion>
+        <shouldOverrideOrgTheme>true</shouldOverrideOrgTheme>
+    </brand>
+    <description>The best way to do X on the Internet!</description>
+    <formFactors>Large</formFactors>
+    <label>My Application</label>
+    <navType>Standard</navType>
+    <tabs>MyApp_File1</tabs>
+    <tabs>MyApp_File2</tabs>
+    <uiType>Lightning</uiType>
+</CustomApplication>

--- a/test/testfiles/force-app/main/default/customMetadata/MyApp_Setting.Default_Configuration.md-meta.xml
+++ b/test/testfiles/force-app/main/default/customMetadata/MyApp_Setting.Default_Configuration.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Default Configuration</label>
+    <protected>true</protected>
+    <values>
+        <field>Foo__c</field>
+        <value xsi:type="xsd:string">01ep3245234cc32f32a34b</value>
+    </values>
+</CustomMetadata>

--- a/test/testfiles/force-app/main/default/customPermissions/MyApp_Admin.customPermissions-meta.xml
+++ b/test/testfiles/force-app/main/default/customPermissions/MyApp_Admin.customPermissions-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomPermission xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Admin permission to view all tabs of My App</description>
+    <isLicensed>false</isLicensed>
+    <label>MyApp Admin Settings</label>
+</CustomPermission>

--- a/test/testfiles/force-app/main/default/objects/Foo__c/Foo__c.object-meta.xml
+++ b/test/testfiles/force-app/main/default/objects/Foo__c/Foo__c.object-meta.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <actionOverrides>
+        <actionName>Accept</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <allowInChatterGroups>false</allowInChatterGroups>
+    <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Used in the lead conversion process</description>
+    <enableHistory>false</enableHistory>
+    <label>Lead Convert Queue</label>
+    <nameField>
+        <displayFormat>LCQ-{00000}</displayFormat>
+        <label>Lead Convert Queue Name</label>
+        <type>AutoNumber</type>
+    </nameField>
+    <pluralLabel>Lead Convert Queue Entries</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/test/testfiles/force-app/main/default/objects/Foo__c/fields/AccessToken_Expr__c.field-meta.xml
+++ b/test/testfiles/force-app/main/default/objects/Foo__c/fields/AccessToken_Expr__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AccessToken_Expr__c</fullName>
+    <externalId>false</externalId>
+    <label x-i18n="comment">Access token expired</label>
+    <description>This is a test.</description>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <type>DateTime</type>
+</CustomField>

--- a/test/testfiles/force-app/main/default/objects/Foo__c/fields/Allocation_status__c.field-meta.xml
+++ b/test/testfiles/force-app/main/default/objects/Foo__c/fields/Allocation_status__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Allocation_status__c</fullName>
+    <externalId>false</externalId>
+    <label x-i18n="comment">Allocation status</label>
+    <description>This is a test.</description>
+    <inlineHelpText>This is inline help text</inlineHelpText>
+    <required>false</required>
+    <length>20</length>
+    <trackHistory>false</trackHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/test/testfiles/force-app/main/default/objects/Foo__c/fields/Collaboration__c.field-meta.xml
+++ b/test/testfiles/force-app/main/default/objects/Foo__c/fields/Collaboration__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Collaboration__c</fullName>
+    <externalId>false</externalId>
+    <label x-i18n="comment">Collaboration</label>
+    <description>This is a test.</description>
+    <inlineHelpText>This is inline help text</inlineHelpText>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <type>Checkbox</type>
+</CustomField>

--- a/test/testfiles/force-app/main/default/objects/Foo__c/fields/Retry_Count__c.field-meta.xml
+++ b/test/testfiles/force-app/main/default/objects/Foo__c/fields/Retry_Count__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Retry_Count__c</fullName>
+    <externalId>false</externalId>
+    <label x-i18n="comment">Retry Count</label>
+    <description>This is a test.</description>
+    <inlineHelpText>This is inline help text</inlineHelpText>
+    <precision>1</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackHistory>false</trackHistory>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/test/testfiles/force-app/main/default/objects/Foo__c/listviews/ListView.listView-meta.xml
+++ b/test/testfiles/force-app/main/default/objects/Foo__c/listviews/ListView.listView-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>All</fullName>
+    <filterScope>Everything</filterScope>
+    <label x-i18n="comment">All items</label>
+</ListView>

--- a/test/testfiles/force-app/main/default/permissionsets/Standard.permissionset-meta.xml
+++ b/test/testfiles/force-app/main/default/permissionsets/Standard.permissionset-meta.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>MyApp</application>
+        <visible>true</visible>
+    </applicationVisibilities>
+    <classAccesses>
+        <application>AdminController</application>
+        <visible>true</visible>
+    </classAccesses>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Foo__c/Foo__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>MyApp Standard</label>
+    <license>Salesforce</license>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>Foo__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <pageAccesses>
+        <apexPage>AccountSection</apexPage>
+        <enabled>true</enabled>
+    </pageAccesses>
+    <tabSettings>
+        <tab>MyApp_Files2</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+</PermissionSet>

--- a/test/testfiles/force-app/main/default/quickActions/SendEmail.quickAction-meta.xml
+++ b/test/testfiles/force-app/main/default/quickActions/SendEmail.quickAction-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<QuickAction xmlns="http://soap.sforce.com/2006/04/metadata">
+    <height>50</height>
+    <label>Send Email</label>
+    <lightningComponent>ObjectSendEmail</lightningComponent>
+    <optionsCreateFeedItem>false</optionsCreateFeedItem>
+    <type>LightningComponent</type>
+    <width>-100</width>
+</QuickAction>

--- a/test/testfiles/force-app/main/default/tabs/MyApp_Files2.tab-meta.xml
+++ b/test/testfiles/force-app/main/default/tabs/MyApp_Files2.tab-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>My Application Files</label>
+    <motif>CRT TV</motif>
+    <page>Main</page>
+</CustomTab>

--- a/test/testfiles/force-app/main/default/translations/en_US.translation-meta.xml
+++ b/test/testfiles/force-app/main/default/translations/en_US.translation-meta.xml
@@ -1,20 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Translations xmlns="http://soap.sforce.com/2006/04/metadata">
     <customApplications>
-        <label><!-- Test --></label>
-        <name>Test</name>
+        <label><!-- The best way to do X on the Internet! --></label>
+        <name>MyApp</name>
     </customApplications>
-    <customApplications>
-        <label><!-- Force.com --></label>
-        <name>Force_com</name>
-    </customApplications>
+    <customField>
+        <label><!-- This is a test. --></label>
+        <name>AcessToken_Expr__c</name>
+    </customField>
+    <customField>
+        <label><!-- This is a test. --></label>
+        <name>Allocation_status__c</name>
+    </customField>
+    <customField>
+        <label><!-- This is a test. --></label>
+        <name>Collaboration__c</name>
+    </customField>
+    <customField>
+        <label><!-- This is a test. --></label>
+        <name>Retry_Count__c</name>
+    </customField>
     <customLabels>
-        <label><!-- Text Account --></label>
-        <name>Account</name>
+        <label><!-- Whether or not the sender should be shown in the recipient list of the email. --></label>
+        <name>Show_Sender_in_Recipient_List</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- Had this been a real test, you would have been instructed to calmly leave the building. --></label>
+        <name>Test_of_emergency_warning_system</name>
+    </customLabels>
+    <customLabels>
+        <label>Translations Only String</label>
+        <name>String_only_in_translations_meta_xml</name>
     </customLabels>
     <customTabs>
-        <label><!-- Files online --></label>
-        <name>Files2</name>
+        <label><!-- My Application Files --></label>
+        <name>MyApp_Files2</name>
     </customTabs>
     <quickActions>
         <label><!-- LogACall --></label>

--- a/test/testfiles/force-app/main/default/translations/en_US.translation-meta.xml
+++ b/test/testfiles/force-app/main/default/translations/en_US.translation-meta.xml
@@ -6,7 +6,7 @@
     </customApplications>
     <customField>
         <label><!-- This is a test. --></label>
-        <name>AcessToken_Expr__c</name>
+        <name>AccessToken_Expr__c</name>
     </customField>
     <customField>
         <label><!-- This is a test. --></label>


### PR DESCRIPTION
- switch to using ilib-loctool-xml for parsing all of the meta.xml file types
    - add schema files for each meta xml file type so that they are handled automatically
- most of the meta.xml file types only contribute source strings to the translation-meta.xml file type
- added a resourceFile path template setting so that users can configure where their translation-meta.xml files go
- updated dependencies